### PR TITLE
remove unused ps_ variables

### DIFF
--- a/helper_lib.sh
+++ b/helper_lib.sh
@@ -1,8 +1,5 @@
 #!/bin/sh
 
-ps_command=$(command -v ps)
-ps_args='-U root -u root -f'
-
 # Returns the absolute path of a given string
 abspath () { case "$1" in /*)printf "%s\n" "$1";; *)printf "%s\n" "$PWD/$1";; esac; }
 


### PR DESCRIPTION
https://github.com/docker/docker-bench-security/commit/362c62ac6e7535197282145be28a6360f15bb8dc made the ps_ variables obsolete.

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>