### PR TITLE
cap-add audit_control and change image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,15 @@
-FROM alpine:3.1
+FROM debian:wheezy
 
-RUN apk --update add docker
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install auditd ca-certificates curl gawk net-tools procps --no-install-recommends && \
+    curl -sSL https://get.docker.com/ | sh && \
+    apt-get -y purge git openssh* patch rsync* && \
+    apt-get -y clean && \
+    apt-get -y autoremove && \
+    rm -rf /var/lib/apt/lists/* \
+      /usr/share/doc /usr/share/doc-base \
+      /usr/share/man /usr/share/locale /usr/share/zoneinfo
 
 RUN mkdir /docker-bench-security
 

--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ The easiest way to run your hosts against the CIS Docker 1.6 benchmark is by run
 
 
 ```sh
-docker run -it --net host --pid host \
+docker run -it --cap-add audit_control --net host --pid host \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/lib/systemd:/usr/lib/systemd \
     -v /etc:/etc --label docker-bench-security \
@@ -33,7 +33,7 @@ If you wish to build and run this container yourself, you can follow the followi
 git clone https://github.com/diogomonica/docker-bench-security.git
 cd docker-bench-security
 docker build -t docker-bench-security .
-docker run -it --net host --pid host \
+docker run -it --cap-add audit_control --net host --pid host \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/lib/systemd:/usr/lib/systemd \
     -v /etc:/etc --label security-benchmark \


### PR DESCRIPTION
Since auditctl doesn't exist in Alpine (issue #19 and https://github.com/docker/docker-bench-security/pull/26#issuecomment-111199481) I propose we switch from Alpine to Debian:wheezy.

@fatherlinux Centos Dockerfile (https://raw.githubusercontent.com/fatherlinux/docker-bench-security/master/Dockerfile.centos) works as well but is bigger in size. `cap_audit_control`  (https://github.com/docker/docker-bench-security/commit/9a87d5e3a723a4d1bad4b69e59376fd11fc74967) is however still needed in order to fix permission issue (https://github.com/docker/docker-bench-security/pull/22#commitcomment-11531161).

```sh
$ docker images | grep docker-bench-security | awk '{print $1, $2, $7,$8}'
docker-bench-security centos 283.5 MB
docker-bench-security debian 115.5 MB
diogomonica/docker-bench-security latest 45.08 MB
```
