### PR TITLE
Fix CIS 5.8 - Reverse container port and reduce privileged port to 1024

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ docker run -it --net host --pid host --cap-add audit_control \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/lib/systemd:/usr/lib/systemd \
     -v /etc:/etc --label security-benchmark \
-    diogomonica/docker-bench-security
+    docker-bench-security
 ```
 
 Also, this script can also be simply run from your base host by running:

--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -201,11 +201,12 @@ else
 
   fail=0
   for c in $containers; do
-    ports=$(docker port "$c" | awk '{print $1}' | cut -d '/' -f1)
+    # Port format is private port -> ip: public port
+    ports=$(docker port "$c" | awk '{print $0}' | cut -d ':' -f2)
 
     # iterate through port range (line delimited)
     for port in $ports; do
-    if [ ! -z "$port" ] && [ "0$port" -lt 1025 ]; then
+    if [ ! -z "$port" ] && [ "0$port" -lt 1024 ]; then
         # If it's the first container, fail the test
         if [ $fail -eq 0 ]; then
           warn "$check_5_8"


### PR DESCRIPTION
-- According to CIS, 5.8 apply to privileged port on the host not on the
container:
`processes are not allowed to use them for various security reasons.
Docker allows a
container port to be mapped to a privileged port.`
-- Also privileged port should be less than 1024 inclusive