### PR TITLE
Some Docker daemon configuration vulnerabilities (section 2) not working correctly

### DIFF
--- a/tests/2_docker_daemon_configuration.sh
+++ b/tests/2_docker_daemon_configuration.sh
@@ -5,7 +5,7 @@ info "2 - Docker Daemon Configuration"
 
 # 2.1
 check_2_1="2.1  - Do not use lxc execution driver"
-pgrep -lf docker | grep lxc >/dev/null 2>&1
+ps ax | grep "docker" | grep lxc >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   warn "$check_2_1"
 else
@@ -14,7 +14,7 @@ fi
 
 # 2.2
 check_2_2="2.2  - Restrict network traffic between containers"
-pgrep -lf docker | grep "icc=false" >/dev/null 2>&1
+ps ax | grep "docker" | grep "icc=false" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   pass "$check_2_2"
 else
@@ -23,7 +23,7 @@ fi
 
 # 2.3
 check_2_3="2.3  - Set the logging level"
-pgrep -lf docker | grep "log-level=\"debug\"" >/dev/null 2>&1
+ps ax | grep "docker" | grep "log-level=\"debug\"" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   warn "$check_2_3"
 else
@@ -32,7 +32,7 @@ fi
 
 # 2.4
 check_2_4="2.4  - Allow Docker to make changes to iptables"
-pgrep -lf docker | grep "iptables=false" >/dev/null 2>&1
+ps ax | grep "docker" | grep "iptables=false" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   warn "$check_2_4"
 else
@@ -41,7 +41,7 @@ fi
 
 # 2.5
 check_2_5="2.5  - Do not use insecure registries"
-pgrep -lf docker | grep "insecure-registry" >/dev/null 2>&1
+ps ax | grep "docker" | grep "insecure-registry" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   warn "$check_2_5"
 else
@@ -50,7 +50,7 @@ fi
 
 # 2.6
 check_2_6="2.6  - Setup a local registry mirror"
-pgrep -lf docker | grep "registry-mirror" >/dev/null 2>&1
+ps ax | grep "docker" | grep "registry-mirror" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   pass "$check_2_6"
 else
@@ -69,7 +69,7 @@ fi
 
 # 2.8
 check_2_8="2.8  - Do not bind Docker to another IP/Port or a Unix socket"
-pgrep -lf docker | grep "\-H" >/dev/null 2>&1
+ps ax | grep "docker" | grep "\-H" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   info "$check_2_8"
   info "     * Docker daemon running with -H"
@@ -79,9 +79,9 @@ fi
 
 # 2.9
 check_2_9="2.9  - Configure TLS authentication for Docker daemon"
-pgrep -lf docker | grep "\-H" >/dev/null 2>&1
+ps ax | grep "docker" | grep "\-H" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-  pgrep -lf docker | grep "tlsverify" | grep "tlskey" >/dev/null 2>&1
+  ps uax | grep "docker" | grep "tlsverify" | grep "tlskey" >/dev/null 2>&1
   if [ $? -eq 0 ]; then
     pass "$check_2_9"
     info "     * Docker daemon currently listening on TCP"
@@ -96,7 +96,7 @@ fi
 
 # 2.10
 check_2_10="2.10 - Set default ulimit as appropriate"
-pgrep -lf docker | grep "default-ulimit" >/dev/null 2>&1
+ps ax | grep "docker" | grep "default-ulimit" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   pass "$check_2_10"
 else


### PR DESCRIPTION
Apparently in ubuntu, pgrep -lf docker does not return the docker process
input parameter.
Thus, all the test that validate command line parameter (e.g., tls
setup, ulimits) does not work.
After replacing pgrep with ps ax all checks are working correctly.

Tested on:
Kernetl version: 3.16.0-37-generic
Ubuntu version: 14.04.1-Ubuntu

Signed-off-by: liron-l <levinlir@gmail.com>