### PR TITLE
Fix for issue #47.

### DIFF
--- a/helper_lib.sh
+++ b/helper_lib.sh
@@ -36,3 +36,13 @@ contains() {
         return 1    # $substring is not in $string
     fi
 }
+
+# Extracts all commandline args from all running processes named like the first parameter
+get_command_line_args() {
+    PROC="$1"
+
+    for PID in `pgrep $PROC`
+    do
+        cat /proc/$PID/cmdline | tr "\0" " "
+    done
+}

--- a/helper_lib.sh
+++ b/helper_lib.sh
@@ -41,7 +41,7 @@ contains() {
 get_command_line_args() {
     PROC="$1"
 
-    for PID in `pgrep $PROC`
+    for PID in `pgrep -x -o $PROC`
     do
         cat /proc/$PID/cmdline | tr "\0" " "
     done

--- a/tests/2_docker_daemon_configuration.sh
+++ b/tests/2_docker_daemon_configuration.sh
@@ -5,7 +5,7 @@ info "2 - Docker Daemon Configuration"
 
 # 2.1
 check_2_1="2.1  - Do not use lxc execution driver"
-pgrep -lf docker | grep lxc >/dev/null 2>&1
+get_command_line_args docker | grep lxc >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   warn "$check_2_1"
 else
@@ -14,7 +14,7 @@ fi
 
 # 2.2
 check_2_2="2.2  - Restrict network traffic between containers"
-pgrep -lf docker | grep "icc=false" >/dev/null 2>&1
+get_command_line_args docker | grep "icc=false" >/dev/null 2>&1 
 if [ $? -eq 0 ]; then
   pass "$check_2_2"
 else
@@ -23,7 +23,7 @@ fi
 
 # 2.3
 check_2_3="2.3  - Set the logging level"
-pgrep -lf docker | grep "log-level=\"debug\"" >/dev/null 2>&1
+get_command_line_args docker | grep "log-level=\"debug\"" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   warn "$check_2_3"
 else
@@ -32,7 +32,7 @@ fi
 
 # 2.4
 check_2_4="2.4  - Allow Docker to make changes to iptables"
-pgrep -lf docker | grep "iptables=false" >/dev/null 2>&1
+get_command_line_args docker | grep "iptables=false" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   warn "$check_2_4"
 else
@@ -41,7 +41,7 @@ fi
 
 # 2.5
 check_2_5="2.5  - Do not use insecure registries"
-pgrep -lf docker | grep "insecure-registry" >/dev/null 2>&1
+get_command_line_args docker | grep "insecure-registry" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   warn "$check_2_5"
 else
@@ -50,7 +50,7 @@ fi
 
 # 2.6
 check_2_6="2.6  - Setup a local registry mirror"
-pgrep -lf docker | grep "registry-mirror" >/dev/null 2>&1
+get_command_line_args docker | grep "registry-mirror" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   pass "$check_2_6"
 else
@@ -69,7 +69,7 @@ fi
 
 # 2.8
 check_2_8="2.8  - Do not bind Docker to another IP/Port or a Unix socket"
-pgrep -lf docker | grep "\-H" >/dev/null 2>&1
+get_command_line_args docker | grep "\-H" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   info "$check_2_8"
   info "     * Docker daemon running with -H"
@@ -79,9 +79,9 @@ fi
 
 # 2.9
 check_2_9="2.9  - Configure TLS authentication for Docker daemon"
-pgrep -lf docker | grep "\-H" >/dev/null 2>&1
+get_command_line_args docker | grep "\-H" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
-  pgrep -lf docker | grep "tlsverify" | grep "tlskey" >/dev/null 2>&1
+  get_command_line_args docker | grep "tlsverify" | grep "tlskey" >/dev/null 2>&1
   if [ $? -eq 0 ]; then
     pass "$check_2_9"
     info "     * Docker daemon currently listening on TCP"
@@ -96,10 +96,11 @@ fi
 
 # 2.10
 check_2_10="2.10 - Set default ulimit as appropriate"
-pgrep -lf docker | grep "default-ulimit" >/dev/null 2>&1
+get_command_line_args docker | grep "default-ulimit" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   pass "$check_2_10"
 else
   info "$check_2_10"
   info "     * Default ulimit doesn't appear to be set"
 fi
+

--- a/tests/3_docker_daemon_configuration_files.sh
+++ b/tests/3_docker_daemon_configuration_files.sh
@@ -292,7 +292,7 @@ fi
 
 # 3.19
 check_3_19="3.19 - Verify that TLS CA certificate file ownership is set to root:root"
-tlscacert=$(pgrep -lf docker | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | cut -d " " -f 1)
 if [ -f "$tlscacert" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_3_19"
@@ -307,7 +307,7 @@ fi
 
 # 3.20
 check_3_20="3.20 - Verify that TLS CA certificate file permissions are set to 444"
-tlscacert=$(pgrep -lf docker | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | cut -d " " -f 1)
 if [ -f "$tlscacert" ]; then
   perms=$(ls -ld "$tlscacert" | awk '{print $1}')
   if [ "$perms" = "-r--r--r--" ]; then
@@ -323,7 +323,7 @@ fi
 
 # 3.21
 check_3_21="3.21 - Verify that Docker server certificate file ownership is set to root:root"
-tlscert=$(pgrep -lf docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlscert=$(get_command_line_args docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | cut -d " " -f 1)
 if [ -f "$tlscert" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_3_21"
@@ -338,7 +338,7 @@ fi
 
 # 3.22
 check_3_22="3.22 - Verify that Docker server certificate file permissions are set to 444"
-tlscacert=$(pgrep -lf docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | cut -d " " -f 1)
 if [ -f "$tlscert" ]; then
   perms=$(ls -ld "$tlscert" | awk '{print $1}')
   if [ "$perms" = "-r--r--r--" ]; then
@@ -354,7 +354,7 @@ fi
 
 # 3.23
 check_3_23="3.23 - Verify that Docker server key file ownership is set to root:root"
-tlskey=$(pgrep -lf docker | sed -n 's/.*tlskey=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlskey=$(get_command_line_args docker | sed -n 's/.*tlskey=\([^s]\)/\1/p' | cut -d " " -f 1)
 if [ -f "$tlskey" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_3_23"
@@ -369,7 +369,7 @@ fi
 
 # 3.24
 check_3_24="3.24 - Verify that Docker server key file permissions are set to 400"
-tlskey=$(pgrep -lf docker | sed -n 's/.*tlskey=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlskey=$(get_command_line_args docker | sed -n 's/.*tlskey=\([^s]\)/\1/p' | cut -d " " -f 1)
 if [ -f "$tlskey" ]; then
   perms=$(ls -ld "$tlskey" | awk '{print $1}')
   if [ "$perms" = "-r--------" ]; then


### PR DESCRIPTION
Introduces a new function in helper_lib.sh to query the command line
arguments of the running instances of a binary. This is done to get
rid of the problem of "-lf" versus "-alf" for pgrep.