### PR TITLE
Distro dir

### DIFF
--- a/distros/Dockerfile.alpine
+++ b/distros/Dockerfile.alpine
@@ -1,0 +1,17 @@
+# REPOSITORY https://github.com/docker/docker-bench-security
+
+MAINTAINER dockerbench.com
+
+FROM alpine:3.1
+
+RUN apk update && \
+    apk upgrade && \
+    apk --update add docker
+
+RUN mkdir /docker-bench-security
+
+COPY . /docker-bench-security
+
+WORKDIR /docker-bench-security
+
+ENTRYPOINT ["/bin/sh", "docker-bench-security.sh"]

--- a/distros/README.md
+++ b/distros/README.md
@@ -1,0 +1,35 @@
+# Distribution specific Dockerfiles
+
+## Requirements
+
+### Keep your images up-to-date
+Use the distribution package manager to keep your image up-to-date.
+
+### REPOSITORY
+Add a `REPOSITORY` comment with the URL to your GitHub repository where the Dockerfile is present.   
+`# REPOSITORY <GitHub repository>`  
+
+### MAINTAINER
+Add the `MAINTAINER` instruction and your contact details, GitHub aliases are acceptable.   
+
+## Example Dockerfile
+
+```sh
+# REPOSITORY https://github.com/docker/docker-bench-security
+
+MAINTAINER dockerbench.com
+
+FROM alpine:3.1
+
+RUN apk update && \
+    apk upgrade && \
+    apk --update add docker
+
+RUN mkdir /docker-bench-security
+
+COPY . /docker-bench-security
+
+WORKDIR /docker-bench-security
+
+ENTRYPOINT ["/bin/sh", "docker-bench-security.sh"]
+```

--- a/distros/README.md
+++ b/distros/README.md
@@ -2,6 +2,9 @@
 
 ## Requirements
 
+### Dockerfile name
+The format should be `Dockerfile.{distribution name}`.  
+
 ### Keep your images up-to-date
 Use the distribution package manager to keep your image up-to-date.
 

--- a/distros/README.md
+++ b/distros/README.md
@@ -15,24 +15,4 @@ Add a `REPOSITORY` comment with the URL to your GitHub repository where the Dock
 ### MAINTAINER
 Add the `MAINTAINER` instruction and your contact details, GitHub aliases are acceptable.   
 
-## Example Dockerfile
-
-```sh
-# REPOSITORY https://github.com/docker/docker-bench-security
-
-MAINTAINER dockerbench.com
-
-FROM alpine:3.1
-
-RUN apk update && \
-    apk upgrade && \
-    apk --update add docker
-
-RUN mkdir /docker-bench-security
-
-COPY . /docker-bench-security
-
-WORKDIR /docker-bench-security
-
-ENTRYPOINT ["/bin/sh", "docker-bench-security.sh"]
-```
+For an example Dockerfile, please refer to `Dockerfile.alpine`.


### PR DESCRIPTION
Add a `distros` directory where distribution specific Dockfiles will be stored, also add a README.md draft.

See issue #19 and comment https://github.com/docker/docker-bench-security/issues/19#issuecomment-112823292

@diogomonica @snrism @fatherlinux