### PR TITLE
Perm checks

### DIFF
--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -74,7 +74,7 @@ fi
 # 1.9
 check_1_9="1.9  - Audit Docker files and directories - /var/lib/docker"
 directory="/var/lib/docker"
-if [ -d "$file" ]; then
+if [ -d "$directory" ]; then
   command -v auditctl >/dev/null 2>&1
   if [ $? -eq 0 ]; then
     auditctl -l | grep $directory >/dev/null 2>&1

--- a/tests/3_docker_daemon_configuration_files.sh
+++ b/tests/3_docker_daemon_configuration_files.sh
@@ -292,7 +292,7 @@ fi
 
 # 3.19
 check_3_19="3.19 - Verify that TLS CA certificate file ownership is set to root:root"
-tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlscacert" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_3_19"
@@ -307,7 +307,7 @@ fi
 
 # 3.20
 check_3_20="3.20 - Verify that TLS CA certificate file permissions are set to 444"
-tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlscacert" ]; then
   perms=$(ls -ld "$tlscacert" | awk '{print $1}')
   if [ "$perms" = "-r--r--r--" ]; then
@@ -323,7 +323,7 @@ fi
 
 # 3.21
 check_3_21="3.21 - Verify that Docker server certificate file ownership is set to root:root"
-tlscert=$(get_command_line_args docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlscert=$(get_command_line_args docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlscert" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_3_21"
@@ -338,7 +338,7 @@ fi
 
 # 3.22
 check_3_22="3.22 - Verify that Docker server certificate file permissions are set to 444"
-tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlscert" ]; then
   perms=$(ls -ld "$tlscert" | awk '{print $1}')
   if [ "$perms" = "-r--r--r--" ]; then
@@ -354,7 +354,7 @@ fi
 
 # 3.23
 check_3_23="3.23 - Verify that Docker server key file ownership is set to root:root"
-tlskey=$(get_command_line_args docker | sed -n 's/.*tlskey=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlskey=$(get_command_line_args docker | sed -n 's/.*tlskey=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlskey" ]; then
   if [ "$(stat -c %u%g $file)" -eq 00 ]; then
     pass "$check_3_23"
@@ -369,7 +369,7 @@ fi
 
 # 3.24
 check_3_24="3.24 - Verify that Docker server key file permissions are set to 400"
-tlskey=$(get_command_line_args docker | sed -n 's/.*tlskey=\([^s]\)/\1/p' | cut -d " " -f 1)
+tlskey=$(get_command_line_args docker | sed -n 's/.*tlskey=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlskey" ]; then
   perms=$(ls -ld "$tlskey" | awk '{print $1}')
   if [ "$perms" = "-r--------" ]; then

--- a/tests/3_docker_daemon_configuration_files.sh
+++ b/tests/3_docker_daemon_configuration_files.sh
@@ -294,7 +294,7 @@ fi
 check_3_19="3.19 - Verify that TLS CA certificate file ownership is set to root:root"
 tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlscacert" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+  if [ "$(stat -c %u%g "$tlscacert")" -eq 00 ]; then
     pass "$check_3_19"
   else
     warn "$check_3_19"
@@ -325,7 +325,7 @@ fi
 check_3_21="3.21 - Verify that Docker server certificate file ownership is set to root:root"
 tlscert=$(get_command_line_args docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlscert" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+  if [ "$(stat -c %u%g "$tlscert")" -eq 00 ]; then
     pass "$check_3_21"
   else
     warn "$check_3_21"
@@ -356,7 +356,7 @@ fi
 check_3_23="3.23 - Verify that Docker server key file ownership is set to root:root"
 tlskey=$(get_command_line_args docker | sed -n 's/.*tlskey=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlskey" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+  if [ "$(stat -c %u%g "$tlskey")" -eq 00 ]; then
     pass "$check_3_23"
   else
     warn "$check_3_23"

--- a/tests/3_docker_daemon_configuration_files.sh
+++ b/tests/3_docker_daemon_configuration_files.sh
@@ -338,7 +338,7 @@ fi
 
 # 3.22
 check_3_22="3.22 - Verify that Docker server certificate file permissions are set to 444"
-tlscacert=$(get_command_line_args docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
+tlscert=$(get_command_line_args docker | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
 if [ -f "$tlscert" ]; then
   perms=$(ls -ld "$tlscert" | awk '{print $1}')
   if [ "$perms" = "-r--r--r--" ]; then


### PR DESCRIPTION
Split /cmdline output so we can get the correct permissions, need to make this prettier.
`stat` didn't stat the correct files.

Closes #52.