### PR TITLE
Get all running containers by name instead of by shor-uuid.

### DIFF
--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -81,8 +81,8 @@ main () {
     labels=$(docker inspect --format '{{ .Config.Labels }}' "$c")
     contains "$labels" "docker-bench-security" && benchcont="$c"
   done
-  # List all running containers except docker-bench
-  containers=$(docker ps -q | grep -v "$benchcont")
+  # List all running containers except docker-bench (use names to improve readability in logs)
+  containers=$(docker ps | sed '1d' |  awk '{print $NF}' | grep -v "$benchcont")
 
   for test in tests/*.sh
   do


### PR DESCRIPTION
To improve readability in logs.

![screen shot 2015-07-23 at 11 27 06](https://cloud.githubusercontent.com/assets/3418603/8847311/e229db14-312d-11e5-8604-5a021a865ef6.png)
