### PR TITLE
alpine 3.1 uses docker 1.4

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 # REPOSITORY https://github.com/docker/docker-bench-security
 
-FROM alpine:3.1
+FROM alpine:3.2
 
 MAINTAINER dockerbench.com
 

--- a/distros/Dockerfile.alpine
+++ b/distros/Dockerfile.alpine
@@ -1,6 +1,6 @@
 # REPOSITORY https://github.com/docker/docker-bench-security
 
-FROM alpine:3.1
+FROM alpine:3.2
 
 MAINTAINER dockerbench.com
 


### PR DESCRIPTION
alpine 3.1 uses docker 1.4 and 3.2 docker 1.6, which is not as bad. will still generate an warning when running the docker-bench-security container, since we marked 1.7 as acceptable.

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>