### PR TITLE
label rule for 1.8

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ docker run -it --net host --pid host --cap-add audit_control \
     -v /var/lib:/var/lib \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/lib/systemd:/usr/lib/systemd \
-    -v /etc:/etc --label docker-bench-security \
+    -v /etc:/etc --label docker_bench_security \
     diogomonica/docker-bench-security
 ```
 
@@ -38,7 +38,7 @@ docker run -it --net host --pid host --cap-add audit_control \
     -v /var/lib:/var/lib \
     -v /var/run/docker.sock:/var/run/docker.sock \
     -v /usr/lib/systemd:/usr/lib/systemd \
-    -v /etc:/etc --label docker-bench-security \
+    -v /etc:/etc --label docker_bench_security \
     docker-bench-security
 ```
 

--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -79,7 +79,7 @@ main () {
   benchcont="nil"
   for c in $containers; do
     labels=$(docker inspect --format '{{ .Config.Labels }}' "$c")
-    contains "$labels" "docker-bench-security" && benchcont="$c"
+    contains "$labels" "docker_bench_security" && benchcont="$c"
   done
   # List all running containers except docker-bench (use names to improve readability in logs)
   containers=$(docker ps | sed '1d' |  awk '{print $NF}' | grep -v "$benchcont")


### PR DESCRIPTION
invalid value "docker-bench-security" for flag --label: poorly formatted environment: variable 'docker-bench-security' is not a valid environment variable

```sh
$ docker version
Client:
 Version:      1.8.0-dev
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   8c7cd78
 Built:        Tue Jul 14 23:47:18 UTC 2015
 OS/Arch:      linux/amd64
 Experimental: true

Server:
 Version:      1.8.0-dev
 API version:  1.20
 Go version:   go1.4.2
 Git commit:   8c7cd78
 Built:        Tue Jul 14 23:47:18 UTC 2015
 OS/Arch:      linux/amd64
 Experimental: true
```

https://github.com/docker/docker/blob/master/opts/envfile.go
```sh
EnvironmentVariableRegexp = regexp.MustCompile("^[[:alpha:]_][[:alpha:][:digit:]_]*$")
```

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>