### PR TITLE
Fix filtering out docker-bench-security container from results

### DIFF
--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -74,7 +74,7 @@ done
 # Load all the tests from tests/ and run them
 main () {
   # List all running containers
-  containers=$(docker ps -q)
+  containers=$(docker ps | sed '1d' | awk '{print $NF}')
   # If there is a container with label docker_bench_security, memorize it:
   benchcont="nil"
   for c in $containers; do


### PR DESCRIPTION
The filtering appears to be a result of the change to use names for running container made in this commit:
https://github.com/docker/docker-bench-security/commit/de68752f30939397eaf01f889a4b2473c93e9e73#diff-3fb01832c41e63e84695c76e31a8e0f9

The grep still uses the short-uuid so fails to filter. This fix places the full name of the container in the benchcont variable so that it is filtered.