### PR TITLE
added cgroup_enable=memory and swapaccount=1 to check for memory enforcement using cgroups

### DIFF
--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -271,3 +271,24 @@ else
   info "$check_1_18"
   info "     * File not found"
 fi
+
+
+# 1.19
+check_1_19="1.19 (extra) - Check cgroup limit for memory and swap"
+file="/proc/cmdline"
+if [ -f "$file" ]; then
+   swaplimit=`cat $file | grep "swapaccount=1"`
+   s_ret=$?
+   cgroup_mem=`cat $file | grep "cgroup_enable=memory"`
+   c_ret=$?
+
+   if [ $s_ret -eq 0  ] && [ $c_ret -eq 0 ]; then
+     pass "$check_1_19"
+   else
+     warn "$check_1_19" 
+     info "     * swapaccount=1 or cgroup_enable=memory not present in /etc/default/grub"
+   fi
+else
+  info "$check_1_19"
+  info "     * File not found"
+fi


### PR DESCRIPTION
By default, the debian kernels are not started with cgroup_enable=memory and awapaccount=1 parameters. As a result, cgroup does not correctly enforce memory and swap limits on a container. This PR checks for these parameters as part of host configuration (Section 1) in /proc/cmdline. If these parameters are not present, it raises a warning.
