### PR TITLE
switch to jessie

### DIFF
--- a/distros/Dockerfile.debian
+++ b/distros/Dockerfile.debian
@@ -1,6 +1,6 @@
 # REPOSITORY https://github.com/konstruktoid/docker-bench-security/
 
-FROM debian:wheezy
+FROM debian:jessie
 
 MAINTAINER Thomas Sjögren <konstruktoid@users.noreply.github.com>
 


### PR DESCRIPTION
Docker 1.8 makes Wheezy fail. Switching to Jessie.
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>