### PR TITLE
alpine: force all packages to be upgraded

### DIFF
--- a/distros/Dockerfile.alpine
+++ b/distros/Dockerfile.alpine
@@ -4,8 +4,9 @@ FROM alpine:3.2
 
 MAINTAINER dockerbench.com
 
+# http://wiki.alpinelinux.org/wiki/Upgrading_Alpine
 RUN apk update && \
-    apk upgrade && \
+    apk upgrade --available && \
     apk --update add docker
 
 RUN mkdir /docker-bench-security


### PR DESCRIPTION
From http://wiki.alpinelinux.org/wiki/Upgrading_Alpine

> The `--available` switch is used to force all packages to be upgraded,
> even if they have the same version numbers.
> Sometimes changes in uClibc require doing this.

It seems prudent to demonstrate canonical upgrade procedure in a security tool.