### PR TITLE
check for TCP socket before checking for TLS

### DIFF
--- a/tests/2_docker_daemon_configuration.sh
+++ b/tests/2_docker_daemon_configuration.sh
@@ -79,7 +79,7 @@ fi
 
 # 2.9
 check_2_9="2.9  - Configure TLS authentication for Docker daemon"
-get_command_line_args docker | grep "\-H\wtcp://" >/dev/null 2>&1
+get_command_line_args docker | tr "-" "\n" | grep -E '^(H|host)' | grep -vE '(unix|fd)://' >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   get_command_line_args docker | grep "tlsverify" | grep "tlskey" >/dev/null 2>&1
   if [ $? -eq 0 ]; then

--- a/tests/2_docker_daemon_configuration.sh
+++ b/tests/2_docker_daemon_configuration.sh
@@ -79,7 +79,7 @@ fi
 
 # 2.9
 check_2_9="2.9  - Configure TLS authentication for Docker daemon"
-get_command_line_args docker | grep "\-H" >/dev/null 2>&1
+get_command_line_args docker | grep "\-H\wtcp://" >/dev/null 2>&1
 if [ $? -eq 0 ]; then
   get_command_line_args docker | grep "tlsverify" | grep "tlskey" >/dev/null 2>&1
   if [ $? -eq 0 ]; then


### PR DESCRIPTION
Test 2.9 was failing with docker-engine 1.9.0rc3 on CentOS 7, when no tcp port was configured.

```bash
$ ps axuwww | grep docker
root     14171  0.2  0.8 540612 31980 ?        Ssl  08:21   0:02 /usr/bin/docker daemon -H fd:// --storage-driver devicemapper --storage-opt dm.thinpooldev=/dev/mapper/centos-docker--pool --storage-opt dm.fs=xfs --icc=false
$
$ sudo ./docker-bench-security.sh 
# ------------------------------------------------------------------------------
# Docker Bench for Security v1.0.0

### SNIP ###

[INFO] 2.8  - Do not bind Docker to another IP/Port or a Unix socket
[INFO]      * Docker daemon running with -H
[WARN] 2.9  - Configure TLS authentication for Docker daemon
[WARN]      * Docker daemon currently listening on TCP without --tlsverify
[INFO] 2.10 - Set default ulimit as appropriate
[INFO]      * Default ulimit doesn't appear to be set

### SNIP ###
$
```


This PR updates the test to look explicitly for TCP daemon sockets before checking for TLS configuration.
