### PR TITLE
Support remote users and groups for group check. Fixes #104

### DIFF
--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -52,7 +52,7 @@ fi
 
 # 1.7
 check_1_7="1.7  - Only allow trusted users to control Docker daemon"
-docker_users=$(grep docker /etc/group)
+docker_users=$(getent group docker)
 info "$check_1_7"
 for u in $docker_users; do
   info "     * $u"


### PR DESCRIPTION
Grepping /etc/group discards users and grous coming from NIS, LDAP, AD.
Use getent group which covers all.