### PR TITLE
keep docker updated, shrink image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,11 +2,22 @@
 
 FROM alpine:3.2
 
+ENV VERSION 1.9.1
+
 MAINTAINER dockerbench.com
+
+WORKDIR /usr/bin
 
 RUN apk update && \
     apk upgrade && \
-    apk --update add docker
+    apk --update add curl && \
+    curl -sS https://get.docker.com/builds/Linux/x86_64/docker-$VERSION > docker-$VERSION && \
+    curl -sS https://get.docker.com/builds/Linux/x86_64/docker-$VERSION.sha256 > docker-$VERSION.sha256 && \
+    sha256sum -c docker-$VERSION.sha256 && \
+    ln -s docker-$VERSION docker && \
+    chmod u+x docker-$VERSION && \
+    apk del curl && \
+    rm -rf /var/cache/apk/*
 
 RUN mkdir /docker-bench-security
 

--- a/distros/Dockerfile.alpine
+++ b/distros/Dockerfile.alpine
@@ -2,11 +2,22 @@
 
 FROM alpine:3.2
 
+ENV VERSION 1.9.1
+
 MAINTAINER dockerbench.com
+
+WORKDIR /usr/bin
 
 RUN apk update && \
     apk upgrade && \
-    apk --update add docker
+    apk --update add curl && \
+    curl -sS https://get.docker.com/builds/Linux/x86_64/docker-$VERSION > docker-$VERSION && \
+    curl -sS https://get.docker.com/builds/Linux/x86_64/docker-$VERSION.sha256 > docker-$VERSION.sha256 && \
+    sha256sum -c docker-$VERSION.sha256 && \
+    ln -s docker-$VERSION docker && \
+    chmod u+x docker-$VERSION && \
+    apk del curl && \
+    rm -rf /var/cache/apk/*
 
 RUN mkdir /docker-bench-security
 


### PR DESCRIPTION
```sh
$ docker run -ti --entrypoint /bin/sh docker-bench-security-local
/docker-bench-security # docker -v
Docker version 1.9.1, build a34a1d5
/docker-bench-security # cd /usr/bin/
/usr/bin # sha256sum -c docker-1.9.1.sha256
docker-1.9.1: OK
/usr/bin # exit
```

```sh
$ docker images | grep docker-bench-security
docker-bench-security-local    latest              641fc44f521a        7 minutes ago       36.03 MB
docker/docker-bench-security   latest              7a31ba994ce2        16 minutes ago      46.47 MB
```

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>