### PR TITLE
convert all tests to functions, add 't' argument, add functions_lib.sh

### DIFF
--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -101,7 +101,7 @@ main () {
 main "$@"
 
 if [ -z "$tests" ]; then
-  cis_checks
+  cis
 else
   "$tests"
 fi

--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -13,6 +13,7 @@
 # Load dependencies
 . ./output_lib.sh
 . ./helper_lib.sh
+. ./functions_lib.sh
 
 # Setup the paths
 this_path=$(abspath "$0")       ## Path of this file including filenamel
@@ -45,11 +46,12 @@ EOF
 # Get the flags
 # If you add an option here, please
 # remember to update usage() above.
-while getopts hl: args
+while getopts hlt: args
 do
   case $args in
   h) usage; exit 0 ;;
   l) logger="$OPTARG" ;;
+  t) tests="$OPTARG";;
   *) usage; exit 1 ;;
   esac
 done
@@ -97,3 +99,10 @@ main () {
 }
 
 main "$@"
+
+if [ -z "$tests" ]; then
+  cis_checks
+else
+  "$tests"
+fi
+

--- a/functions_lib.sh
+++ b/functions_lib.sh
@@ -1,0 +1,122 @@
+#!/bin/sh
+
+host_configuration() {
+  check_1
+  check_1_1
+  check_1_2
+  check_1_5
+  check_1_6
+  check_1_7
+  check_1_8
+  check_1_9
+  check_1_10
+  check_1_11
+  check_1_12
+  check_1_13
+  check_1_14
+  check_1_15
+  check_1_16
+  check_1_17
+  check_1_18
+}
+
+docker_daemon_configuration() {
+  check_2
+  check_2_1
+  check_2_2
+  check_2_3
+  check_2_4
+  check_2_5
+  check_2_6
+  check_2_7
+  check_2_8
+  check_2_9
+  check_2_10
+}
+
+docker_daemon_files() {
+  check_3
+  check_3_1
+  check_3_2
+  check_3_3
+  check_3_4
+  check_3_5
+  check_3_6
+  check_3_7
+  check_3_8
+  check_3_9
+  check_3_10
+  check_3_11
+  check_3_12
+  check_3_13
+  check_3_14
+  check_3_15
+  check_3_16
+  check_3_17
+  check_3_18
+  check_3_19
+  check_3_20
+  check_3_21
+  check_3_22
+  check_3_23
+  check_3_24
+  check_3_25
+  check_3_26
+}
+
+container_images() {
+  check_4
+  check_4_1
+}
+
+container_runtime() {
+  check_5
+  check_running_containers
+  check_5_1
+  check_5_2
+  check_5_3
+  check_5_4
+  check_5_5
+  check_5_6
+  check_5_8
+  check_5_8
+  check_5_10
+  check_5_11
+  check_5_12
+  check_5_12
+  check_5_14
+  check_5_15
+  check_5_16
+  check_5_17
+  check_5_18
+  check_5_19
+}
+
+docker_security_operations() {
+  check_6
+  check_6_5
+  check_6_6
+  check_6_7
+}
+
+# CIS
+cis() {
+  host_configuration
+  docker_daemon_configuration
+  docker_daemon_files
+  container_images
+  container_runtime
+  docker_security_operations
+}
+
+# Community contributed
+community() {
+  check_community
+  check_community_1
+}
+
+# All
+all() {
+  cis
+  community
+}

--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -1,277 +1,311 @@
 #!/bin/sh
 
+check_1() {
 logit ""
 info "1 - Host Configuration"
+}
 
 # 1.1
-check_1_1="1.1  - Create a separate partition for containers"
-grep /var/lib/docker /etc/fstab >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  pass "$check_1_1"
-else
-  warn "$check_1_1"
-fi
+check_1_1() {
+  check_check_1_1="1.1  - Create a separate partition for containers"
+  grep /var/lib/docker /etc/fstab >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    pass "$check_check_1_1"
+  else
+    warn "$check_check_1_1"
+  fi
+}
 
 # 1.2
-check_1_2="1.2  - Use an updated Linux Kernel"
-kernel_version=$(uname -r | cut -d "-" -f 1)
-do_version_check 3.10 "$kernel_version"
-if [ $? -eq 11 ]; then
-  warn "$check_1_2"
-else
-  pass "$check_1_2"
-fi
+check_1_2() {
+  check_check_1_2="1.2  - Use an updated Linux Kernel"
+  kernel_version=$(uname -r | cut -d "-" -f 1)
+  do_version_check 3.10 "$kernel_version"
+  if [ $? -eq 11 ]; then
+    warn "$check_check_1_2"
+  else
+    pass "$check_check_1_2"
+  fi
+}
 
 # 1.5
-check_1_5="1.5  - Remove all non-essential services from the host - Network"
-# Check for listening network services.
-listening_services=$(netstat -na | grep -v tcp6 | grep -v unix | grep -c LISTEN)
-if [ "$listening_services" -eq 0 ]; then
-  warn "1.5  - Failed to get listening services for check: $check_1_5"
-else
-  if [ "$listening_services" -gt 5 ]; then
-    warn "$check_1_5"
-    warn "     * Host listening on: $listening_services ports"
+check_1_5() {
+  check_check_1_5="1.5  - Remove all non-essential services from the host - Network"
+  # Check for listening network services.
+  listening_services=$(netstat -na | grep -v tcp6 | grep -v unix | grep -c LISTEN)
+  if [ "$listening_services" -eq 0 ]; then
+    warn "1.5  - Failed to get listening services for check: $check_check_1_5"
   else
-    pass "$check_1_5"
+    if [ "$listening_services" -gt 5 ]; then
+      warn "$check_check_1_5"
+      warn "     * Host listening on: $listening_services ports"
+    else
+      pass "$check_check_1_5"
+    fi
   fi
-fi
+}
 
 # 1.6
-check_1_6="1.6  - Keep Docker up to date"
-docker_version=$(docker version | grep -i -A1 '^server' | grep -i 'version:' \
-  | awk '{print $NF; exit}' | tr -d '[:alpha:]-,')
-docker_current_version="1.9.1"
-docker_current_date="2015-11-09"
-do_version_check "$docker_current_version" "$docker_version"
-if [ $? -eq 11 ]; then
-  warn "$check_1_6"
-  warn "      * Using $docker_version, when $docker_current_version is current as of $docker_current_date"
-  info "      * Your operating system vendor may provide support and security maintenance for docker"
-else
-  pass "$check_1_6"
-  info "      * Using $docker_version which is current as of $docker_current_date"
-  info "      * Check with your operating system vendor for support and security maintenance for docker"
-fi
+check_1_6() {
+  check_check_1_6="1.6  - Keep Docker up to date"
+  docker_version=$(docker version | grep -i -A1 '^server' | grep -i 'version:' \
+    | awk '{print $NF; exit}' | tr -d '[:alpha:]-,')
+  docker_current_version="1.9.1"
+  docker_current_date="2015-11-09"
+  do_version_check "$docker_current_version" "$docker_version"
+  if [ $? -eq 11 ]; then
+    warn "$check_check_1_6"
+    warn "      * Using $docker_version, when $docker_current_version is current as of $docker_current_date"
+    info "      * Your operating system vendor may provide support and security maintenance for docker"
+  else
+    pass "$check_check_1_6"
+    info "      * Using $docker_version which is current as of $docker_current_date"
+    info "      * Check with your operating system vendor for support and security maintenance for docker"
+  fi
+}
 
 # 1.7
-check_1_7="1.7  - Only allow trusted users to control Docker daemon"
-docker_users=$(getent group docker)
-info "$check_1_7"
-for u in $docker_users; do
-  info "     * $u"
-done
+check_1_7() {
+  check_check_1_7="1.7  - Only allow trusted users to control Docker daemon"
+  docker_users=$(getent group docker)
+  info "$check_check_1_7"
+  for u in $docker_users; do
+    info "     * $u"
+  done
+}
 
 # 1.8
-check_1_8="1.8  - Audit docker daemon"
-command -v auditctl >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  auditctl -l | grep /usr/bin/docker >/dev/null 2>&1
+check_1_8() {
+  check_check_1_8="1.8  - Audit docker daemon"
+  command -v auditctl >/dev/null 2>&1
   if [ $? -eq 0 ]; then
-    pass "$check_1_8"
+    auditctl -l | grep /usr/bin/docker >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      pass "$check_check_1_8"
+    else
+      warn "$check_check_1_8"
+    fi
   else
-    warn "$check_1_8"
+    warn "1.8  - Failed to inspect: auditctl command not found."
   fi
-else
-  warn "1.8  - Failed to inspect: auditctl command not found."
-fi
+}
 
 # 1.9
-check_1_9="1.9  - Audit Docker files and directories - /var/lib/docker"
-directory="/var/lib/docker"
-if [ -d "$directory" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $directory >/dev/null 2>&1
+check_1_9() {
+  check_check_1_9="1.9  - Audit Docker files and directories - /var/lib/docker"
+  directory="/var/lib/docker"
+  if [ -d "$directory" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_9"
+      auditctl -l | grep $directory >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_9"
+      else
+        warn "$check_check_1_9"
+      fi
     else
-      warn "$check_1_9"
+      warn "1.9  - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.9  - Failed to inspect: auditctl command not found."
+    info "$check_check_1_9"
+    info "     * Directory not found"
   fi
-else
-  info "$check_1_9"
-  info "     * Directory not found"
-fi
+}
 
 # 1.10
-check_1_10="1.10 - Audit Docker files and directories - /etc/docker"
-directory="/etc/docker"
-if [ -d "$directory" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $directory >/dev/null 2>&1
+check_1_10() {
+  check_check_1_10="1.10 - Audit Docker files and directories - /etc/docker"
+  directory="/etc/docker"
+  if [ -d "$directory" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_10"
+      auditctl -l | grep $directory >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_10"
+      else
+        warn "$check_check_1_10"
+      fi
     else
-      warn "$check_1_10"
+      warn "1.10 - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.10 - Failed to inspect: auditctl command not found."
+    info "$check_check_1_10"
+    info "     * Directory not found"
   fi
-else
-  info "$check_1_10"
-  info "     * Directory not found"
-fi
+}
 
 # 1.11
-check_1_11="1.11 - Audit Docker files and directories - docker-registry.service"
-file="$(get_systemd_service_file docker-registry.service)"
-if [ -f "$file" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $file >/dev/null 2>&1
+check_1_11() {
+  check_check_1_11="1.11 - Audit Docker files and directories - docker-registry.service"
+  file="$(get_systemd_service_file docker-registry.service)"
+  if [ -f "$file" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_11"
+      auditctl -l | grep $file >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_11"
+      else
+        warn "$check_check_1_11"
+      fi
     else
-      warn "$check_1_11"
+      warn "1.11 - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.11 - Failed to inspect: auditctl command not found."
+    info "$check_check_1_11"
+    info "     * File not found"
   fi
-else
-  info "$check_1_11"
-  info "     * File not found"
-fi
+}
 
 # 1.12
-check_1_12="1.12 - Audit Docker files and directories - docker.service"
-file="$(get_systemd_service_file docker.service)"
-if [ -f "$file" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $file >/dev/null 2>&1
+check_1_12() {
+  check_check_1_12="1.12 - Audit Docker files and directories - docker.service"
+  file="$(get_systemd_service_file docker.service)"
+  if [ -f "$file" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_12"
+      auditctl -l | grep $file >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_12"
+      else
+        warn "$check_check_1_12"
+      fi
     else
-      warn "$check_1_12"
+      warn "1.12 - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.12 - Failed to inspect: auditctl command not found."
+    info "$check_check_1_12"
+    info "     * File not found"
   fi
-else
-  info "$check_1_12"
-  info "     * File not found"
-fi
+}
 
 # 1.13
-check_1_13="1.13 - Audit Docker files and directories - /var/run/docker.sock"
-file="/var/run/docker.sock"
-if [ -e "$file" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $file >/dev/null 2>&1
+check_1_13() {
+  check_check_1_13="1.13 - Audit Docker files and directories - /var/run/docker.sock"
+  file="/var/run/docker.sock"
+  if [ -e "$file" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_13"
+      auditctl -l | grep $file >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_13"
+      else
+        warn "$check_check_1_13"
+      fi
     else
-      warn "$check_1_13"
+      warn "1.13 - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.13 - Failed to inspect: auditctl command not found."
+    info "$check_check_1_13"
+    info "     * File not found"
   fi
-else
-  info "$check_1_13"
-  info "     * File not found"
-fi
+}
 
 # 1.14
-check_1_14="1.14 - Audit Docker files and directories - /etc/sysconfig/docker"
-file="/etc/sysconfig/docker"
-if [ -f "$file" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $file >/dev/null 2>&1
+check_1_14() {
+  check_check_1_14="1.14 - Audit Docker files and directories - /etc/sysconfig/docker"
+  file="/etc/sysconfig/docker"
+  if [ -f "$file" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_14"
+      auditctl -l | grep $file >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_14"
+      else
+        warn "$check_check_1_14"
+      fi
     else
-      warn "$check_1_14"
+      warn "1.14 - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.14 - Failed to inspect: auditctl command not found."
+    info "$check_check_1_14"
+    info "     * File not found"
   fi
-else
-  info "$check_1_14"
-  info "     * File not found"
-fi
+}
 
 # 1.15
-check_1_15="1.15 - Audit Docker files and directories - /etc/sysconfig/docker-network"
-file="/etc/sysconfig/docker-network"
-if [ -f "$file" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $file >/dev/null 2>&1
+check_1_15() {
+  check_check_1_15="1.15 - Audit Docker files and directories - /etc/sysconfig/docker-network"
+  file="/etc/sysconfig/docker-network"
+  if [ -f "$file" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_15"
+      auditctl -l | grep $file >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_15"
+      else
+        warn "$check_check_1_15"
+      fi
     else
-      warn "$check_1_15"
+      warn "1.15 - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.15 - Failed to inspect: auditctl command not found."
+    info "$check_check_1_15"
+    info "     * File not found"
   fi
-else
-  info "$check_1_15"
-  info "     * File not found"
-fi
+}
 
 # 1.16
-check_1_16="1.16 - Audit Docker files and directories - /etc/sysconfig/docker-registry"
-file="/etc/sysconfig/docker-registry"
-if [ -f "$file" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $file >/dev/null 2>&1
+check_1_16() {
+  check_check_1_16="1.16 - Audit Docker files and directories - /etc/sysconfig/docker-registry"
+  file="/etc/sysconfig/docker-registry"
+  if [ -f "$file" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_16"
+      auditctl -l | grep $file >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_16"
+      else
+        warn "$check_check_1_16"
+      fi
     else
-      warn "$check_1_16"
+      warn "1.16 - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.16 - Failed to inspect: auditctl command not found."
+    info "$check_check_1_16"
+    info "     * File not found"
   fi
-else
-  info "$check_1_16"
-  info "     * File not found"
-fi
+}
 
 # 1.17
-check_1_17="1.17 - Audit Docker files and directories - /etc/sysconfig/docker-storage"
-file="/etc/sysconfig/docker-storage"
-if [ -f "$file" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $file >/dev/null 2>&1
+check_1_17() {
+  check_check_1_17="1.17 - Audit Docker files and directories - /etc/sysconfig/docker-storage"
+  file="/etc/sysconfig/docker-storage"
+  if [ -f "$file" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_17"
+      auditctl -l | grep $file >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_17"
+      else
+        warn "$check_check_1_17"
+      fi
     else
-      warn "$check_1_17"
+      warn "1.17 - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.17 - Failed to inspect: auditctl command not found."
+    info "$check_check_1_17"
+    info "     * File not found"
   fi
-else
-  info "$check_1_17"
-  info "     * File not found"
-fi
+}
 
 # 1.18
-check_1_18="1.18 - Audit Docker files and directories - /etc/default/docker"
-file="/etc/default/docker"
-if [ -f "$file" ]; then
-  command -v auditctl >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    auditctl -l | grep $file >/dev/null 2>&1
+check_1_18() {
+  check_check_1_18="1.18 - Audit Docker files and directories - /etc/default/docker"
+  file="/etc/default/docker"
+  if [ -f "$file" ]; then
+    command -v auditctl >/dev/null 2>&1
     if [ $? -eq 0 ]; then
-      pass "$check_1_18"
+      auditctl -l | grep $file >/dev/null 2>&1
+      if [ $? -eq 0 ]; then
+        pass "$check_check_1_18"
+      else
+        warn "$check_check_1_18"
+      fi
     else
-      warn "$check_1_18"
+      warn "1.18 - Failed to inspect: auditctl command not found."
     fi
   else
-    warn "1.18 - Failed to inspect: auditctl command not found."
+    info "$check_check_1_18"
+    info "     * File not found"
   fi
-else
-  info "$check_1_18"
-  info "     * File not found"
-fi
+}

--- a/tests/2_docker_daemon_configuration.sh
+++ b/tests/2_docker_daemon_configuration.sh
@@ -1,106 +1,127 @@
 #!/bin/sh
 
-logit "\n"
-info "2 - Docker Daemon Configuration"
+check_2() {
+  logit "\n"
+  info "2 - Docker Daemon Configuration"
+}
 
 # 2.1
-check_2_1="2.1  - Do not use lxc execution driver"
-get_command_line_args docker | grep lxc >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  warn "$check_2_1"
-else
-  pass "$check_2_1"
-fi
+check_2_1() {
+  check_2_1="2.1  - Do not use lxc execution driver"
+  get_command_line_args docker | grep lxc >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    warn "$check_2_1"
+  else
+    pass "$check_2_1"
+  fi
+}
 
 # 2.2
-check_2_2="2.2  - Restrict network traffic between containers"
-get_docker_effective_command_line_args '--icc' | grep "false" >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  pass "$check_2_2"
-else
-  warn "$check_2_2"
-fi
+check_2_2() {
+  check_2_2="2.2  - Restrict network traffic between containers"
+  get_docker_effective_command_line_args '--icc' | grep "false" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    pass "$check_2_2"
+  else
+    warn "$check_2_2"
+  fi
+}
 
 # 2.3
-check_2_3="2.3  - Set the logging level"
-get_docker_effective_command_line_args '-l' | grep "debug" >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  warn "$check_2_3"
-else
-  pass "$check_2_3"
-fi
+check_2_3() {
+  check_2_3="2.3  - Set the logging level"
+  get_docker_effective_command_line_args '-l' | grep "debug" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    warn "$check_2_3"
+  else
+    pass "$check_2_3"
+  fi
+}
 
 # 2.4
-check_2_4="2.4  - Allow Docker to make changes to iptables"
-get_docker_effective_command_line_args '--iptables' | grep "false" >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  warn "$check_2_4"
-else
-  pass "$check_2_4"
-fi
+check_2_4() {
+  check_2_4="2.4  - Allow Docker to make changes to iptables"
+  get_docker_effective_command_line_args '--iptables' | grep "false" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    warn "$check_2_4"
+  else
+    pass "$check_2_4"
+  fi
+}
 
 # 2.5
-check_2_5="2.5  - Do not use insecure registries"
-get_docker_effective_command_line_args '--insecure-registry' | grep "insecure-registry" >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  warn "$check_2_5"
-else
-  pass "$check_2_5"
-fi
+check_2_5() {
+  check_2_5="2.5  - Do not use insecure registries"
+  get_docker_effective_command_line_args '--insecure-registry' | grep "insecure-registry" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    warn "$check_2_5"
+  else
+    pass "$check_2_5"
+  fi
+}
 
 # 2.6
-check_2_6="2.6  - Setup a local registry mirror"
-get_docker_effective_command_line_args '--registry-mirror' | grep "registry-mirror" >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  pass "$check_2_6"
-else
-  info "$check_2_6"
-  info "     * No local registry currently configured"
-fi
+check_2_6() {
+  check_2_6="2.6  - Setup a local registry mirror"
+  get_docker_effective_command_line_args '--registry-mirror' | grep "registry-mirror" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    pass "$check_2_6"
+  else
+    info "$check_2_6"
+    info "     * No local registry currently configured"
+  fi
+}
 
 # 2.7
-check_2_7="2.7  - Do not use the aufs storage driver"
-docker info 2>/dev/null | grep -e "^Storage Driver:\s*aufs\s*$" >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  warn "$check_2_7"
-else
-  pass "$check_2_7"
-fi
+check_2_7() {
+  check_2_7="2.7  - Do not use the aufs storage driver"
+  docker info 2>/dev/null | grep -e "^Storage Driver:\s*aufs\s*$" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    warn "$check_2_7"
+  else
+    pass "$check_2_7"
+  fi
+}
 
 # 2.8
-check_2_8="2.8  - Do not bind Docker to another IP/Port or a Unix socket"
-get_docker_effective_command_line_args '-H' | grep "\-H" >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  info "$check_2_8"
-  info "     * Docker daemon running with -H"
-else
-  pass "$check_2_8"
-fi
+check_2_8() {
+  check_2_8="2.8  - Do not bind Docker to another IP/Port or a Unix socket"
+  get_docker_effective_command_line_args '-H' | grep "\-H" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    info "$check_2_8"
+    info "     * Docker daemon running with -H"
+  else
+    pass "$check_2_8"
+  fi
+}
 
 # 2.9
-check_2_9="2.9  - Configure TLS authentication for Docker daemon"
-get_docker_cumulative_command_line_args '-H' | grep -vE '(unix|fd)://' >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  get_command_line_args docker | grep "tlsverify" | grep "tlskey" >/dev/null 2>&1
+check_2_9() {
+  check_2_9="2.9  - Configure TLS authentication for Docker daemon"
+  get_docker_cumulative_command_line_args '-H' | grep -vE '(unix|fd)://' >/dev/null 2>&1
   if [ $? -eq 0 ]; then
-    pass "$check_2_9"
-    info "     * Docker daemon currently listening on TCP"
+    get_command_line_args docker | grep "tlsverify" | grep "tlskey" >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      pass "$check_2_9"
+      info "     * Docker daemon currently listening on TCP"
+    else
+      warn "$check_2_9"
+      warn "     * Docker daemon currently listening on TCP without --tlsverify"
+    fi
   else
-    warn "$check_2_9"
-    warn "     * Docker daemon currently listening on TCP without --tlsverify"
+    info "$check_2_9"
+    info "     * Docker daemon not listening on TCP"
   fi
-else
-  info "$check_2_9"
-  info "     * Docker daemon not listening on TCP"
-fi
+}
 
 # 2.10
-check_2_10="2.10 - Set default ulimit as appropriate"
-get_docker_effective_command_line_args '--default-ulimit' | grep "default-ulimit" >/dev/null 2>&1
-if [ $? -eq 0 ]; then
-  pass "$check_2_10"
-else
-  info "$check_2_10"
-  info "     * Default ulimit doesn't appear to be set"
-fi
-
+check_2_10() {
+  check_2_10="2.10 - Set default ulimit as appropriate"
+  get_docker_effective_command_line_args '--default-ulimit' | grep "default-ulimit" >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    pass "$check_2_10"
+  else
+    info "$check_2_10"
+    info "     * Default ulimit doesn't appear to be set"
+  fi
+}

--- a/tests/3_docker_daemon_configuration_files.sh
+++ b/tests/3_docker_daemon_configuration_files.sh
@@ -1,415 +1,469 @@
 #!/bin/sh
 
-logit "\n"
-info "3 - Docker Daemon Configuration Files"
+check_3() {
+  logit "\n"
+  info "3 - Docker Daemon Configuration Files"
+}
 
 # 3.1
-check_3_1="3.1  - Verify that docker.service file ownership is set to root:root"
-file="$(get_systemd_service_file docker.service)"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-    pass "$check_3_1"
+check_3_1() {
+  check_3_1="3.1  - Verify that docker.service file ownership is set to root:root"
+  file="$(get_systemd_service_file docker.service)"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+      pass "$check_3_1"
+    else
+      warn "$check_3_1"
+      warn "     * Wrong ownership for $file"
+    fi
   else
-    warn "$check_3_1"
-    warn "     * Wrong ownership for $file"
+    info "$check_3_1"
+    info "     * File not found"
   fi
-else
-  info "$check_3_1"
-  info "     * File not found"
-fi
+}
 
 # 3.2
-check_3_2="3.2  - Verify that docker.service file permissions are set to 644"
-file="$(get_systemd_service_file docker.service)"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 ]; then
-    pass "$check_3_2"
+check_3_2() {
+  check_3_2="3.2  - Verify that docker.service file permissions are set to 644"
+  file="$(get_systemd_service_file docker.service)"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %a $file)" -eq 644 ]; then
+      pass "$check_3_2"
+    else
+      warn "$check_3_2"
+      warn "     * Wrong permissions for $file"
+    fi
   else
-    warn "$check_3_2"
-    warn "     * Wrong permissions for $file"
+    info "$check_3_2"
+    info "     * File not found"
   fi
-else
-  info "$check_3_2"
-  info "     * File not found"
-fi
+}
 
 # 3.3
-check_3_3="3.3  - Verify that docker-registry.service file ownership is set to root:root"
-file="$(get_systemd_service_file docker-registry.service)"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-    pass "$check_3_3"
+check_3_3() {
+  check_3_3="3.3  - Verify that docker-registry.service file ownership is set to root:root"
+  file="$(get_systemd_service_file docker-registry.service)"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+      pass "$check_3_3"
+    else
+      warn "$check_3_3"
+      warn "     * Wrong ownership for $file"
+    fi
   else
-    warn "$check_3_3"
-    warn "     * Wrong ownership for $file"
+    info "$check_3_3"
+    info "     * File not found"
   fi
-else
-  info "$check_3_3"
-  info "     * File not found"
-fi
+}
 
 # 3.4
-check_3_4="3.4  - Verify that docker-registry.service file permissions are set to 644"
-file="$(get_systemd_service_file docker-registry.service)"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 ]; then
-    pass "$check_3_4"
+check_3_4() {
+  check_3_4="3.4  - Verify that docker-registry.service file permissions are set to 644"
+  file="$(get_systemd_service_file docker-registry.service)"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %a $file)" -eq 644 ]; then
+      pass "$check_3_4"
+    else
+      warn "$check_3_4"
+      warn "     * Wrong permissions for $file"
+    fi
   else
-    warn "$check_3_4"
-    warn "     * Wrong permissions for $file"
+    info "$check_3_4"
+    info "     * File not found"
   fi
-else
-  info "$check_3_4"
-  info "     * File not found"
-fi
+}
 
 # 3.5
-check_3_5="3.5  - Verify that docker.socket file ownership is set to root:root"
-file="$(get_systemd_service_file docker.socket)"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-    pass "$check_3_5"
+check_3_5() {
+  check_3_5="3.5  - Verify that docker.socket file ownership is set to root:root"
+  file="$(get_systemd_service_file docker.socket)"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+      pass "$check_3_5"
+    else
+      warn "$check_3_5"
+      warn "     * Wrong ownership for $file"
+    fi
   else
-    warn "$check_3_5"
-    warn "     * Wrong ownership for $file"
+    info "$check_3_5"
+    info "     * File not found"
   fi
-else
-  info "$check_3_5"
-  info "     * File not found"
-fi
+}
 
 # 3.6
-check_3_6="3.6  - Verify that docker.socket file permissions are set to 644"
-file="$(get_systemd_service_file docker.socket)"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 ]; then
-    pass "$check_3_6"
+check_3_6() {
+  check_3_6="3.6  - Verify that docker.socket file permissions are set to 644"
+  file="$(get_systemd_service_file docker.socket)"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %a $file)" -eq 644 ]; then
+      pass "$check_3_6"
+    else
+      warn "$check_3_6"
+      warn "     * Wrong permissions for $file"
+    fi
   else
-    warn "$check_3_6"
-    warn "     * Wrong permissions for $file"
+    info "$check_3_6"
+    info "     * File not found"
   fi
-else
-  info "$check_3_6"
-  info "     * File not found"
-fi
+}
 
 # 3.7
-check_3_7="3.7  - Verify that Docker environment file ownership is set to root:root "
-file="/etc/sysconfig/docker"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-    pass "$check_3_7"
+check_3_7() {
+  check_3_7="3.7  - Verify that Docker environment file ownership is set to root:root "
+  file="/etc/sysconfig/docker"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+      pass "$check_3_7"
+    else
+      warn "$check_3_7"
+      warn "     * Wrong ownership for $file"
+    fi
   else
-    warn "$check_3_7"
-    warn "     * Wrong ownership for $file"
+    info "$check_3_7"
+    info "     * File not found"
   fi
-else
-  info "$check_3_7"
-  info "     * File not found"
-fi
+}
 
 # 3.8
-check_3_8="3.8  - Verify that Docker environment file permissions are set to 644"
-file="/etc/sysconfig/docker"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 ]; then
-    pass "$check_3_8"
+check_3_8() {
+  check_3_8="3.8  - Verify that Docker environment file permissions are set to 644"
+  file="/etc/sysconfig/docker"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %a $file)" -eq 644 ]; then
+      pass "$check_3_8"
+    else
+      warn "$check_3_8"
+      warn "     * Wrong permissions for $file"
+    fi
   else
-    warn "$check_3_8"
-    warn "     * Wrong permissions for $file"
+    info "$check_3_8"
+    info "     * File not found"
   fi
-else
-  info "$check_3_8"
-  info "     * File not found"
-fi
+}
 
 # 3.9
-check_3_9="3.9  - Verify that docker-network environment file ownership is set to root:root"
-file="/etc/sysconfig/docker-network"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-    pass "$check_3_9"
+check_3_9() {
+  check_3_9="3.9  - Verify that docker-network environment file ownership is set to root:root"
+  file="/etc/sysconfig/docker-network"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+      pass "$check_3_9"
+    else
+      warn "$check_3_9"
+      warn "     * Wrong ownership for $file"
+    fi
   else
-    warn "$check_3_9"
-    warn "     * Wrong ownership for $file"
+    info "$check_3_9"
+    info "     * File not found"
   fi
-else
-  info "$check_3_9"
-  info "     * File not found"
-fi
+}
 
 # 3.10
-check_3_10="3.10 - Verify that docker-network environment file permissions are set to 644"
-file="/etc/sysconfig/docker-network"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 ]; then
-    pass "$check_3_10"
+check_3_10() {
+  check_3_10="3.10 - Verify that docker-network environment file permissions are set to 644"
+  file="/etc/sysconfig/docker-network"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %a $file)" -eq 644 ]; then
+      pass "$check_3_10"
+    else
+      warn "$check_3_10"
+      warn "     * Wrong permissions for $file"
+    fi
   else
-    warn "$check_3_10"
-    warn "     * Wrong permissions for $file"
+    info "$check_3_10"
+    info "     * File not found"
   fi
-else
-  info "$check_3_10"
-  info "     * File not found"
-fi
+}
 
 # 3.11
-check_3_11="3.11 - Verify that docker-registry environment file ownership is set to root:root"
-file="/etc/sysconfig/docker-registry"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-    pass "$check_3_11"
+check_3_11() {
+  check_3_11="3.11 - Verify that docker-registry environment file ownership is set to root:root"
+  file="/etc/sysconfig/docker-registry"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+      pass "$check_3_11"
+    else
+      warn "$check_3_11"
+      warn "     * Wrong ownership for $file"
+    fi
   else
-    warn "$check_3_11"
-    warn "     * Wrong ownership for $file"
+    info "$check_3_11"
+    info "     * File not found"
   fi
-else
-  info "$check_3_11"
-  info "     * File not found"
-fi
+}
 
 # 3.12
-check_3_12="3.12 - Verify that docker-registry environment file permissions are set to 644"
-file="/etc/sysconfig/docker-registry"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 ]; then
-    pass "$check_3_12"
+check_3_12() {
+  check_3_12="3.12 - Verify that docker-registry environment file permissions are set to 644"
+  file="/etc/sysconfig/docker-registry"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %a $file)" -eq 644 ]; then
+      pass "$check_3_12"
+    else
+      warn "$check_3_12"
+      warn "     * Wrong permissions for $file"
+    fi
   else
-    warn "$check_3_12"
-    warn "     * Wrong permissions for $file"
+    info "$check_3_12"
+    info "     * File not found"
   fi
-else
-  info "$check_3_12"
-  info "     * File not found"
-fi
+}
 
 # 3.13
-check_3_13="3.13 - Verify that docker-storage environment file ownership is set to root:root"
-file="/etc/sysconfig/docker-storage"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %u%g $file)" -eq 00 ]; then
-    pass "$check_3_13"
+check_3_13() {
+  check_3_13="3.13 - Verify that docker-storage environment file ownership is set to root:root"
+  file="/etc/sysconfig/docker-storage"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %u%g $file)" -eq 00 ]; then
+      pass "$check_3_13"
+    else
+      warn "$check_3_13"
+      warn "     * Wrong ownership for $file"
+    fi
   else
-    warn "$check_3_13"
-    warn "     * Wrong ownership for $file"
+    info "$check_3_13"
+    info "     * File not found"
   fi
-else
-  info "$check_3_13"
-  info "     * File not found"
-fi
+}
 
 # 3.14
-check_3_14="3.14 - Verify that docker-storage environment file permissions are set to 644"
-file="/etc/sysconfig/docker-storage"
-if [ -f "$file" ]; then
-  if [ "$(stat -c %a $file)" -eq 644 ]; then
-    pass "$check_3_14"
+check_3_14() {
+  check_3_14="3.14 - Verify that docker-storage environment file permissions are set to 644"
+  file="/etc/sysconfig/docker-storage"
+  if [ -f "$file" ]; then
+    if [ "$(stat -c %a $file)" -eq 644 ]; then
+      pass "$check_3_14"
+    else
+      warn "$check_3_14"
+      warn "     * Wrong permissions for $file"
+    fi
   else
-    warn "$check_3_14"
-    warn "     * Wrong permissions for $file"
+    info "$check_3_14"
+    info "     * File not found"
   fi
-else
-  info "$check_3_14"
-  info "     * File not found"
-fi
+}
 
 # 3.15
-check_3_15="3.15 - Verify that /etc/docker directory ownership is set to root:root"
-directory="/etc/docker"
-if [ -d "$directory" ]; then
-  if [ "$(stat -c %u%g $directory)" -eq 00 ]; then
-    pass "$check_3_15"
+check_3_15() {
+  check_3_15="3.15 - Verify that /etc/docker directory ownership is set to root:root"
+  directory="/etc/docker"
+  if [ -d "$directory" ]; then
+    if [ "$(stat -c %u%g $directory)" -eq 00 ]; then
+      pass "$check_3_15"
+    else
+      warn "$check_3_15"
+      warn "     * Wrong ownership for $directory"
+    fi
   else
-    warn "$check_3_15"
-    warn "     * Wrong ownership for $directory"
+    info "$check_3_15"
+    info "     * Directory not found"
   fi
-else
-  info "$check_3_15"
-  info "     * Directory not found"
-fi
+}
 
 # 3.16
-check_3_16="3.16 - Verify that /etc/docker directory permissions are set to 755"
-directory="/etc/docker"
-if [ -d "$directory" ]; then
-  if [ "$(stat -c %a $directory)" -eq 755 ]; then
-    pass "$check_3_16"
-  elif [ "$(stat -c %a $directory)" -eq 700 ]; then
-    pass "$check_3_16"
+check_3_16() {
+  check_3_16="3.16 - Verify that /etc/docker directory permissions are set to 755"
+  directory="/etc/docker"
+  if [ -d "$directory" ]; then
+    if [ "$(stat -c %a $directory)" -eq 755 ]; then
+      pass "$check_3_16"
+    elif [ "$(stat -c %a $directory)" -eq 700 ]; then
+      pass "$check_3_16"
+    else
+      warn "$check_3_16"
+      warn "     * Wrong permissions for $directory"
+    fi
   else
-    warn "$check_3_16"
-    warn "     * Wrong permissions for $directory"
+    info "$check_3_16"
+    info "     * Directory not found"
   fi
-else
-  info "$check_3_16"
-  info "     * Directory not found"
-fi
+}
 
 # 3.17
-check_3_17="3.17 - Verify that registry certificate file ownership is set to root:root"
-directory="/etc/docker/certs.d/"
-if [ -d "$directory" ]; then
-  fail=0
-  owners=$(ls -lL $directory | grep ".crt" | awk '{print $3, $4}')
-  for p in $owners; do
-    printf "%s" "$p" | grep "root" >/dev/null 2>&1
-    if [ $? -ne 0 ]; then
-      fail=1
+check_3_17() {
+  check_3_17="3.17 - Verify that registry certificate file ownership is set to root:root"
+  directory="/etc/docker/certs.d/"
+  if [ -d "$directory" ]; then
+    fail=0
+    owners=$(ls -lL $directory | grep ".crt" | awk '{print $3, $4}')
+    for p in $owners; do
+      printf "%s" "$p" | grep "root" >/dev/null 2>&1
+      if [ $? -ne 0 ]; then
+        fail=1
+      fi
+    done
+    if [ $fail -eq 1 ]; then
+      warn "$check_3_17"
+      warn "     * Wrong ownership for $directory"
+    else
+      pass "$check_3_17"
     fi
-  done
-  if [ $fail -eq 1 ]; then
-    warn "$check_3_17"
-    warn "     * Wrong ownership for $directory"
   else
-    pass "$check_3_17"
+    info "$check_3_17"
+    info "     * Directory not found"
   fi
-else
-  info "$check_3_17"
-  info "     * Directory not found"
-fi
+}
 
 # 3.18
-check_3_18="3.18 - Verify that registry certificate file permissions are set to 444"
-directory="/etc/docker/certs.d/"
-if [ -d "$directory" ]; then
-  fail=0
-  perms=$(ls -lL $directory | grep ".crt" | awk '{print $1}')
-  for p in $perms; do
-    if [ "$p" != "-r--r--r--." -a "$p" = "-r--------." ]; then
-      fail=1
+check_3_18() {
+  check_3_18="3.18 - Verify that registry certificate file permissions are set to 444"
+  directory="/etc/docker/certs.d/"
+  if [ -d "$directory" ]; then
+    fail=0
+    perms=$(ls -lL $directory | grep ".crt" | awk '{print $1}')
+    for p in $perms; do
+      if [ "$p" != "-r--r--r--." -a "$p" = "-r--------." ]; then
+        fail=1
+      fi
+    done
+    if [ $fail -eq 1 ]; then
+      warn "$check_3_18"
+      warn "     * Wrong permissions for $directory"
+    else
+      pass "$check_3_18"
     fi
-  done
-  if [ $fail -eq 1 ]; then
-    warn "$check_3_18"
-    warn "     * Wrong permissions for $directory"
   else
-    pass "$check_3_18"
+    info "$check_3_18"
+    info "     * Directory not found"
   fi
-else
-  info "$check_3_18"
-  info "     * Directory not found"
-fi
+}
 
 # 3.19
-check_3_19="3.19 - Verify that TLS CA certificate file ownership is set to root:root"
-tlscacert=$(get_docker_effective_command_line_args '--tlscacert' | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
-if [ -f "$tlscacert" ]; then
-  if [ "$(stat -c %u%g "$tlscacert")" -eq 00 ]; then
-    pass "$check_3_19"
+check_3_19() {
+  check_3_19="3.19 - Verify that TLS CA certificate file ownership is set to root:root"
+  tlscacert=$(get_docker_effective_command_line_args '--tlscacert' | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
+  if [ -f "$tlscacert" ]; then
+    if [ "$(stat -c %u%g "$tlscacert")" -eq 00 ]; then
+      pass "$check_3_19"
+    else
+      warn "$check_3_19"
+      warn "     * Wrong ownership for $tlscacert"
+    fi
   else
-    warn "$check_3_19"
-    warn "     * Wrong ownership for $tlscacert"
+    info "$check_3_19"
+    info "     * No TLS CA certificate found"
   fi
-else
-  info "$check_3_19"
-  info "     * No TLS CA certificate found"
-fi
+}
 
 # 3.20
-check_3_20="3.20 - Verify that TLS CA certificate file permissions are set to 444"
-tlscacert=$(get_docker_effective_command_line_args '--tlscacert' | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
-if [ -f "$tlscacert" ]; then
-  perms=$(ls -ld "$tlscacert" | awk '{print $1}')
-  if [ "$perms" = "-r--r--r--" ]; then
-    pass "$check_3_20"
+check_3_20() {
+  check_3_20="3.20 - Verify that TLS CA certificate file permissions are set to 444"
+  tlscacert=$(get_docker_effective_command_line_args '--tlscacert' | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
+  if [ -f "$tlscacert" ]; then
+    perms=$(ls -ld "$tlscacert" | awk '{print $1}')
+    if [ "$perms" = "-r--r--r--" ]; then
+      pass "$check_3_20"
+    else
+      warn "$check_3_20"
+      warn "     * Wrong permissions for $tlscacert"
+    fi
   else
-    warn "$check_3_20"
-    warn "     * Wrong permissions for $tlscacert"
+    info "$check_3_20"
+    info "     * No TLS CA certificate found"
   fi
-else
-  info "$check_3_20"
-  info "     * No TLS CA certificate found"
-fi
+}
 
 # 3.21
-check_3_21="3.21 - Verify that Docker server certificate file ownership is set to root:root"
-tlscert=$(get_docker_effective_command_line_args '--tlscert' | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
-if [ -f "$tlscert" ]; then
-  if [ "$(stat -c %u%g "$tlscert")" -eq 00 ]; then
-    pass "$check_3_21"
+check_3_21() {
+  check_3_21="3.21 - Verify that Docker server certificate file ownership is set to root:root"
+  tlscert=$(get_docker_effective_command_line_args '--tlscert' | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
+  if [ -f "$tlscert" ]; then
+    if [ "$(stat -c %u%g "$tlscert")" -eq 00 ]; then
+      pass "$check_3_21"
+    else
+      warn "$check_3_21"
+      warn "     * Wrong ownership for $tlscert"
+    fi
   else
-    warn "$check_3_21"
-    warn "     * Wrong ownership for $tlscert"
+    info "$check_3_21"
+    info "     * No TLS Server certificate found"
   fi
-else
-  info "$check_3_21"
-  info "     * No TLS Server certificate found"
-fi
+}
 
 # 3.22
-check_3_22="3.22 - Verify that Docker server certificate file permissions are set to 444"
-tlscert=$(get_docker_effective_command_line_args '--tlscert' | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
-if [ -f "$tlscert" ]; then
-  perms=$(ls -ld "$tlscert" | awk '{print $1}')
-  if [ "$perms" = "-r--r--r--" ]; then
-    pass "$check_3_22"
+check_3_22() {
+  check_3_22="3.22 - Verify that Docker server certificate file permissions are set to 444"
+  tlscert=$(get_docker_effective_command_line_args '--tlscert' | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
+  if [ -f "$tlscert" ]; then
+    perms=$(ls -ld "$tlscert" | awk '{print $1}')
+    if [ "$perms" = "-r--r--r--" ]; then
+      pass "$check_3_22"
+    else
+      warn "$check_3_22"
+      warn "     * Wrong permissions for $tlscert"
+    fi
   else
-    warn "$check_3_22"
-    warn "     * Wrong permissions for $tlscert"
+    info "$check_3_22"
+    info "     * No TLS Server certificate found"
   fi
-else
-  info "$check_3_22"
-  info "     * No TLS Server certificate found"
-fi
+}
 
 # 3.23
-check_3_23="3.23 - Verify that Docker server key file ownership is set to root:root"
-tlskey=$(get_docker_effective_command_line_args '--tlskey' | sed -n 's/.*tlskey=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
-if [ -f "$tlskey" ]; then
-  if [ "$(stat -c %u%g "$tlskey")" -eq 00 ]; then
-    pass "$check_3_23"
+check_3_23() {
+  check_3_23="3.23 - Verify that Docker server key file ownership is set to root:root"
+  tlskey=$(get_docker_effective_command_line_args '--tlskey' | sed -n 's/.*tlskey=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
+  if [ -f "$tlskey" ]; then
+    if [ "$(stat -c %u%g "$tlskey")" -eq 00 ]; then
+      pass "$check_3_23"
+    else
+      warn "$check_3_23"
+      warn "     * Wrong ownership for $tlskey"
+    fi
   else
-    warn "$check_3_23"
-    warn "     * Wrong ownership for $tlskey"
+    info "$check_3_23"
+    info "     * No TLS Key found"
   fi
-else
-  info "$check_3_23"
-  info "     * No TLS Key found"
-fi
+}
 
 # 3.24
-check_3_24="3.24 - Verify that Docker server key file permissions are set to 400"
-tlskey=$(get_docker_effective_command_line_args '--tlskey' | sed -n 's/.*tlskey=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
-if [ -f "$tlskey" ]; then
-  perms=$(ls -ld "$tlskey" | awk '{print $1}')
-  if [ "$perms" = "-r--------" ]; then
-    pass "$check_3_24"
+check_3_24() {
+  check_3_24="3.24 - Verify that Docker server key file permissions are set to 400"
+  tlskey=$(get_docker_effective_command_line_args '--tlskey' | sed -n 's/.*tlskey=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
+  if [ -f "$tlskey" ]; then
+    perms=$(ls -ld "$tlskey" | awk '{print $1}')
+    if [ "$perms" = "-r--------" ]; then
+      pass "$check_3_24"
+    else
+      warn "$check_3_24"
+      warn "     * Wrong permissions for $tlskey"
+    fi
   else
-    warn "$check_3_24"
-    warn "     * Wrong permissions for $tlskey"
+    info "$check_3_24"
+    info "     * No TLS Key found"
   fi
-else
-  info "$check_3_24"
-  info "     * No TLS Key found"
-fi
+}
 
 # 3.25
-check_3_25="3.25 - Verify that Docker socket file ownership is set to root:docker"
-file="/var/run/docker.sock"
-if [ -S "$file" ]; then
-  if [ "$(stat -c %U:%G $file)" = 'root:docker' ]; then
-    pass "$check_3_25"
+check_3_25(){
+  check_3_25="3.25 - Verify that Docker socket file ownership is set to root:docker"
+  file="/var/run/docker.sock"
+  if [ -S "$file" ]; then
+    if [ "$(stat -c %U:%G $file)" = 'root:docker' ]; then
+      pass "$check_3_25"
+    else
+      warn "$check_3_25"
+      warn "     * Wrong ownership for $file"
+    fi
   else
-    warn "$check_3_25"
-    warn "     * Wrong ownership for $file"
+    info "$check_3_25"
+    info "     * File not found"
   fi
-else
-  info "$check_3_25"
-  info "     * File not found"
-fi
+}
 
 # 3.26
-check_3_26="3.26 - Verify that Docker socket file permissions are set to 660"
-file="/var/run/docker.sock"
-if [ -S "$file" ]; then
-  perms=$(ls -ld "$file" | awk '{print $1}')
-  if [ "$perms" = "srw-rw----" ]; then
-    pass "$check_3_26"
+check_3_26() {
+  check_3_26="3.26 - Verify that Docker socket file permissions are set to 660"
+  file="/var/run/docker.sock"
+  if [ -S "$file" ]; then
+    perms=$(ls -ld "$file" | awk '{print $1}')
+    if [ "$perms" = "srw-rw----" ]; then
+      pass "$check_3_26"
+    else
+      warn "$check_3_26"
+      warn "     * Wrong permissions for $file"
+    fi
   else
-    warn "$check_3_26"
-    warn "     * Wrong permissions for $file"
+    info "$check_3_26"
+    info "     * File not found"
   fi
-else
-  info "$check_3_26"
-  info "     * File not found"
-fi
+}

--- a/tests/4_container_images.sh
+++ b/tests/4_container_images.sh
@@ -1,39 +1,43 @@
 #!/bin/sh
 
-logit "\n"
-info "4 - Container Images and Build Files"
+check_4() {
+  logit "\n"
+  info "4 - Container Images and Build Files"
+}
 
 # 4.1
-check_4_1="4.1  - Create a user for the container"
+check_4_1() {
+  check_4_1="4.1  - Create a user for the container"
 
-# If container_users is empty, there are no running containers
-if [ -z "$containers" ]; then
-  info "$check_4_1"
-  info "     * No containers running"
-else
-  # We have some containers running, set failure flag to 0. Check for Users.
-  fail=0
-  # Make the loop separator be a new-line in POSIX compliant fashion
-  set -f; IFS=$'
-'
-  for c in $containers; do
-    user=$(docker inspect --format 'User={{.Config.User}}' "$c")
+  # If container_users is empty, there are no running containers
+  if [ -z "$containers" ]; then
+    info "$check_4_1"
+    info "     * No containers running"
+  else
+    # We have some containers running, set failure flag to 0. Check for Users.
+    fail=0
+    # Make the loop separator be a new-line in POSIX compliant fashion
+    set -f; IFS=$'
+  '
+    for c in $containers; do
+      user=$(docker inspect --format 'User={{.Config.User}}' "$c")
 
-    if [ "$user" = "User=" -o "$user" = "User=[]" -o "$user" = "User=<no value>" ]; then
-      # If it's the first container, fail the test
-      if [ $fail -eq 0 ]; then
-        warn "$check_4_1"
-        warn "     * Running as root: $c"
-        fail=1
-      else
-        warn "     * Running as root: $c"
+      if [ "$user" = "User=" -o "$user" = "User=[]" -o "$user" = "User=<no value>" ]; then
+        # If it's the first container, fail the test
+        if [ $fail -eq 0 ]; then
+          warn "$check_4_1"
+          warn "     * Running as root: $c"
+          fail=1
+        else
+          warn "     * Running as root: $c"
+        fi
       fi
-    fi
-  done
-  # We went through all the containers and found none running as root
-  if [ $fail -eq 0 ]; then
+    done
+    # We went through all the containers and found none running as root
+    if [ $fail -eq 0 ]; then
       pass "$check_4_1"
+    fi
   fi
-fi
-# Make the loop separator go back to space
-set +f; unset IFS
+  # Make the loop separator go back to space
+  set +f; unset IFS
+}

--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -1,16 +1,29 @@
 #!/bin/sh
 
+check_5() {
 logit "\n"
 info "5  - Container Runtime"
+}
 
-# If containers is empty, there are no running containers
-if [ -z "$containers" ]; then
-  info "     * No containers running, skipping Section 5"
-else
-  # Make the loop separator be a new-line in POSIX compliant fashion
-  set -f; IFS=$'
-'
-  # 5.1
+check_running_containers() {
+  # If containers is empty, there are no running containers
+  if [ -z "$containers" ]; then
+    info "     * No containers running, skipping Section 5"
+    running_containers=0
+  else
+    running_containers=1
+    # Make the loop separator be a new-line in POSIX compliant fashion
+    set -f; IFS=$'
+  '
+  fi
+}
+
+# 5.1
+check_5_1() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_1="5.1  - Verify AppArmor Profile, if applicable"
 
   fail=0
@@ -32,8 +45,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_1"
   fi
+}
 
-  # 5.2
+# 5.2
+check_5_2() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_2="5.2  - Verify SELinux security options, if applicable"
 
   fail=0
@@ -55,8 +74,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_2"
   fi
+}
 
-  # 5.3
+# 5.3
+check_5_3() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_3="5.3  - Verify that containers are running only a single main process"
 
   fail=0
@@ -90,8 +115,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_3"
   fi
+}
 
-  # 5.4
+# 5.4
+check_5_4() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_4="5.4  - Restrict Linux Kernel Capabilities within containers"
 
   fail=0
@@ -113,8 +144,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_4"
   fi
+}
 
-  # 5.5
+# 5.5
+check_5_5() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_5="5.5  - Do not use privileged containers"
 
   fail=0
@@ -136,8 +173,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_5"
   fi
+}
 
-  # 5.6
+# 5.6
+check_5_6() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_6="5.6  - Do not mount sensitive host system directories on containers"
 
   # List of sensitive directories to test for. Script uses new-lines as a separator.
@@ -178,8 +221,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_6"
   fi
+}
 
-  # 5.7
+# 5.7
+check_5_8() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_7="5.7  - Do not run ssh within containers"
 
   fail=0
@@ -214,8 +263,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_7"
   fi
+}
 
-  # 5.8
+# 5.8
+check_5_8() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_8="5.8  - Do not map privileged ports within containers"
 
   fail=0
@@ -241,8 +296,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_8"
   fi
+}
 
-  # 5.10
+# 5.10
+check_5_10() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_10="5.10 - Do not use host network mode on container"
 
   fail=0
@@ -264,8 +325,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_10"
   fi
+}
 
-  # 5.11
+# 5.11
+check_5_11() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_11="5.11 - Limit memory usage for container"
 
   fail=0
@@ -293,8 +360,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_11"
   fi
+}
 
-  # 5.12
+# 5.12
+check_5_12() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_12="5.12 - Set container CPU priority appropriately"
 
   fail=0
@@ -322,8 +395,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_12"
   fi
+}
 
-  # 5.13
+# 5.13
+check_5_12(){
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_13="5.13 - Mount container's root filesystem as read only"
 
   fail=0
@@ -345,8 +424,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_13"
   fi
+}
 
-  # 5.14
+# 5.14
+check_5_14() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_14="5.14 - Bind incoming container traffic to a specific host interface"
 
   fail=0
@@ -368,8 +453,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_14"
   fi
+}
 
-  # 5.15
+# 5.15
+check_5_15() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_15="5.15 - Do not set the 'on-failure' container restart policy to always"
 
   fail=0
@@ -391,8 +482,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_15"
   fi
+}
 
-  # 5.16
+# 5.16
+check_5_16() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_16="5.16 - Do not share the host's process namespace"
 
   fail=0
@@ -414,8 +511,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_16"
   fi
+}
 
-  # 5.17
+# 5.17
+check_5_17() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_17="5.17 - Do not share the host's IPC namespace"
 
   fail=0
@@ -437,8 +540,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_17"
   fi
+}
 
-  # 5.18
+# 5.18
+check_5_18() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_18="5.18 - Do not directly expose host devices to containers"
 
   fail=0
@@ -460,8 +569,14 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_18"
   fi
+}
 
-  # 5.19
+# 5.19
+check_5_19() {
+  if [ "$running_containers" -ne 1 ]; then
+    return
+  fi
+
   check_5_19="5.19 - Override default ulimit at runtime only if needed"
 
   # List all the running containers, ouput their ID and host devices
@@ -484,4 +599,4 @@ else
   if [ $fail -eq 0 ]; then
       pass "$check_5_19"
   fi
-fi
+} 

--- a/tests/6_docker_security_operations.sh
+++ b/tests/6_docker_security_operations.sh
@@ -1,77 +1,85 @@
 #!/bin/sh
 
-logit "\n"
-info "6  - Docker Security Operations"
+check_6() {
+  logit "\n"
+  info "6  - Docker Security Operations"
+}
 
 # 6.5
-check_6_5="6.5 - Use a centralized and remote log collection service"
+check_6_5() {
+  check_6_5="6.5 - Use a centralized and remote log collection service"
 
-# If containers is empty, there are no running containers
-if [ -z "$containers" ]; then
-  info "$check_6_5"
-  info "     * No containers running"
-else
-  fail=0
-  set -f; IFS=$'
-'
-  for c in $containers; do
-    docker inspect --format '{{ .Volumes }}' "$c" 2>/dev/null 1>&2
+  # If containers is empty, there are no running containers
+  if [ -z "$containers" ]; then
+    info "$check_6_5"
+    info "     * No containers running"
+  else
+    fail=0
+    set -f; IFS=$'
+  '
+    for c in $containers; do
+      docker inspect --format '{{ .Volumes }}' "$c" 2>/dev/null 1>&2
 
-    if [ $? -eq 0 ]; then
-      volumes=$(docker inspect --format '{{ .Volumes }}' "$c")
-    else
-      volumes=$(docker inspect --format '{{ .Config.Volumes }}' "$c")
-    fi
-
-    if [ "$volumes" = "map[]" ]; then
-      # If it's the first container, fail the test
-      if [ $fail -eq 0 ]; then
-        info "$check_6_5"
-        info "     * Container has no volumes, ensure centralized logging is enabled : $c"
-        fail=1
+      if [ $? -eq 0 ]; then
+        volumes=$(docker inspect --format '{{ .Volumes }}' "$c")
       else
-        info "     * Container has no volumes, ensure centralized logging is enabled : $c"
+        volumes=$(docker inspect --format '{{ .Config.Volumes }}' "$c")
       fi
-    fi
-  done
-  # Only alert if there are no volumes. If there are volumes, can't know if they
-  # are used for logs
-fi
-# Make the loop separator go back to space
-set +f; unset IFS
+
+      if [ "$volumes" = "map[]" ]; then
+        # If it's the first container, fail the test
+        if [ $fail -eq 0 ]; then
+          info "$check_6_5"
+          info "     * Container has no volumes, ensure centralized logging is enabled : $c"
+          fail=1
+        else
+          info "     * Container has no volumes, ensure centralized logging is enabled : $c"
+        fi
+      fi
+    done
+    # Only alert if there are no volumes. If there are volumes, can't know if they
+    # are used for logs
+  fi
+  # Make the loop separator go back to space
+  set +f; unset IFS
+}
 
 # 6.6
-check_6_6="6.6 - Avoid image sprawl"
-images=$(docker images -q | sort -u | wc -l | awk '{print $1}')
-active_images=0
+check_6_6() {
+  check_6_6="6.6 - Avoid image sprawl"
+  images=$(docker images -q | sort -u | wc -l | awk '{print $1}')
+  active_images=0
 
-for c in $(docker inspect -f "{{.Image}}" $(docker ps -qa)); do
-  if docker images --no-trunc -a | grep "$c" > /dev/null ; then
-    active_images=$(( active_images += 1 ))
+  for c in $(docker inspect -f "{{.Image}}" $(docker ps -qa)); do
+    if docker images --no-trunc -a | grep "$c" > /dev/null ; then
+      active_images=$(( active_images += 1 ))
+    fi
+  done
+
+  if [ "$images" -gt 100 ]; then
+    warn "$check_6_6"
+    warn "     * There are currently: $images images"
+  else
+    info "$check_6_6"
+    info "     * There are currently: $images images"
   fi
-done
 
-if [ "$images" -gt 100 ]; then
-  warn "$check_6_6"
-  warn "     * There are currently: $images images"
-else
-  info "$check_6_6"
-  info "     * There are currently: $images images"
-fi
-
-if [ "$active_images" -lt "$((images / 2))" ]; then
-  warn "     * Only $active_images out of $images are in use"
-fi
+  if [ "$active_images" -lt "$((images / 2))" ]; then
+    warn "     * Only $active_images out of $images are in use"
+  fi
+}
 
 # 6.7
-check_6_7="6.7 - Avoid container sprawl"
-total_containers=$(docker info 2>/dev/null | grep "Containers" | awk '{print $2}')
-running_containers=$(docker ps -q | wc -l | awk '{print $1}')
-diff="$((total_containers - running_containers))"
-if [ "$diff" -gt 25 ]; then
-  warn "$check_6_7"
-  warn "     * There are currently a total of $total_containers containers, with only $running_containers of them currently running"
-else
-  info "$check_6_7"
-  info "     * There are currently a total of $total_containers containers, with $running_containers of them currently running"
-fi
+check_6_7() {
+  check_6_7="6.7 - Avoid container sprawl"
+  total_containers=$(docker info 2>/dev/null | grep "Containers" | awk '{print $2}')
+  running_containers=$(docker ps -q | wc -l | awk '{print $1}')
+  diff="$((total_containers - running_containers))"
+  if [ "$diff" -gt 25 ]; then
+    warn "$check_6_7"
+    warn "     * There are currently a total of $total_containers containers, with only $running_containers of them currently running"
+  else
+    info "$check_6_7"
+    info "     * There are currently a total of $total_containers containers, with $running_containers of them currently running"
+  fi
+}

--- a/tests/X_community_tests.sh
+++ b/tests/X_community_tests.sh
@@ -1,0 +1,12 @@
+#!/bin/sh
+check_community() {
+  logit "\n"
+  info "X - Community contributed tests"
+}
+
+check_community_1() {
+  check_community_1="X.1 - Placeholder"
+
+  echo "This is just a placeholder."
+}
+


### PR DESCRIPTION
Here's a big bloated pre-1.10 blob of a PR.

It converts all tests to functions, which I then group up according to the present tests categories.
It also adds the 't' argument which is used to specify which group of tests should run, the current groups are `cis` (default), `community` (community contributed tests), and `all`.

This PR could serve as base for https://github.com/docker/docker-bench-security/issues/38#issuecomment-112903895 (even though we haven't converted this project to Go), #51 and makes it easier to implement community contributed tests (as those tend do pop-up as PR:s).

Ping @diogomonica 

``` sh
$ sudo sh docker-bench-security.sh -t community
# ------------------------------------------------------------------------------
# Docker Bench for Security v1.0.0
#
# Docker, Inc. (c) 2015
#
# Checks for dozens of common best-practices around deploying Docker containers in production.
# Inspired by the CIS Docker 1.6 Benchmark:
# https://benchmarks.cisecurity.org/tools2/docker/CIS_Docker_1.6_Benchmark_v1.0.0.pdf
# ------------------------------------------------------------------------------

Initializing Sun Jan 31 21:38:27 CET 2016



[INFO] X - Community contributed tests
This is just a placeholder.
```

Signed-off-by: Thomas Sjögren konstruktoid@users.noreply.github.com
