### PR TITLE
ps flags not in output

### DIFF
--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -62,7 +62,7 @@ else
   fail=0
   printcheck=0
   for c in $containers; do
-    processes=$(docker exec "$c" ps -el 2>/dev/null | tail -n +2 | grep -c -v "ps -el")
+    processes=$(docker exec "$c" ps -el 2>/dev/null | tail -n +2 | grep -c -v 'ps')
     if [ "$processes" -gt 1 ]; then
       # If it's the first container, fail the test
       if [ $fail -eq 0 ]; then


### PR DESCRIPTION
`ps` wasn't excluded since grep included the ps arguments 

Closes #129 
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>