### PR TITLE
Output without terminal color codes

### DIFF
--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -11,7 +11,6 @@
 # ------------------------------------------------------------------------------
 
 # Load dependencies
-. ./output_lib.sh
 . ./helper_lib.sh
 
 # Setup the paths
@@ -38,6 +37,7 @@ usage () {
   usage: ${myname} [options]
 
   -h           optional  Print this help message
+  -m           optional  Disable colors in output
   -l PATH      optional  Log output in PATH
 EOF
 }
@@ -45,14 +45,19 @@ EOF
 # Get the flags
 # If you add an option here, please
 # remember to update usage() above.
-while getopts hl: args
+outputlib='output_lib.sh'
+
+while getopts hml: args
 do
   case $args in
   h) usage; exit 0 ;;
+  m) outputlib='textout_lib.sh' ;;
   l) logger="$OPTARG" ;;
   *) usage; exit 1 ;;
   esac
 done
+
+. ./${outputlib}
 
 if [ -z "$logger" ]; then
   logger="${myname}.log"

--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -41,8 +41,8 @@ fi
 check_1_6="1.6  - Keep Docker up to date"
 docker_version=$(docker version | grep -i -A1 '^server' | grep -i 'version:' \
   | awk '{print $NF; exit}' | tr -d '[:alpha:]-,')
-docker_current_version="1.10.0"
-docker_current_date="2016-01-05"
+docker_current_version="1.10.1"
+docker_current_date="2016-02-11"
 do_version_check "$docker_current_version" "$docker_version"
 if [ $? -eq 11 ]; then
   warn "$check_1_6"

--- a/textout_lib.sh
+++ b/textout_lib.sh
@@ -1,0 +1,26 @@
+#!/bin/sh
+bldred=''
+bldgrn=''
+bldblu=''
+bldylw=''
+txtrst=''
+
+logit () {
+  printf "%b\n" "$1" | tee -a "$logger"
+}
+
+info () {
+  printf "%b\n" "${bldblu}[INFO]${txtrst} $1" | tee -a "$logger"
+}
+
+pass () {
+  printf "%b\n" "${bldgrn}[PASS]${txtrst} $1" | tee -a "$logger"
+}
+
+warn () {
+  printf "%b\n" "${bldred}[WARN]${txtrst} $1" | tee -a "$logger"
+}
+
+yell () {
+  printf "%b\n" "${bldylw}$1${txtrst}\n"
+}


### PR DESCRIPTION
Add a secondary output helper library which does not set terminal colors;
Add a command-line switch to invoke "Monochrome" mode (-m);
Source the appropriate output helper library after command line options have been parsed.

... and some spare commits to get everything signed off 🤕 . 