### PR TITLE
use debian:sid for docker.io

### DIFF
--- a/distros/Dockerfile.debian
+++ b/distros/Dockerfile.debian
@@ -1,13 +1,13 @@
 # REPOSITORY https://github.com/konstruktoid/docker-bench-security/
 
-FROM debian:stretch
+FROM debian:sid
 
 MAINTAINER Thomas Sjögren <konstruktoid@users.noreply.github.com>
 
 RUN \
     apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install auditd ca-certificates docker.io\
+    apt-get -y install auditd ca-certificates docker.io \
       gawk net-tools procps --no-install-recommends && \
     apt-get -y clean && \
     apt-get -y autoremove && \


### PR DESCRIPTION
Seems that Docker, both docker.io and docker-engine, has been removed from majority of Debian releases. Switching to sid.

https://packages.debian.org/search?suite=default&section=all&arch=any&lang=en&searchon=names&keywords=docker
https://packages.debian.org/search?suite=default&section=all&arch=any&lang=en&searchon=names&keywords=docker.io

Closes #177
Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>