### PR TITLE
Add HEALTHCHECK -> removes warning from 4.6

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,5 +18,7 @@ COPY ./tests/*.sh /usr/local/bin/tests/
 
 WORKDIR /usr/local/bin
 
+HEALTHCHECK CMD exit 0
+
 ENTRYPOINT [ "/usr/bin/dumb-init", "docker-bench-security.sh" ]
 


### PR DESCRIPTION
This will prevent:
```bash
# Docker Bench for Security v1.3.0
[WARN] 4.6  - Add HEALTHCHECK instruction to the container image
[WARN]      * No Healthcheck found: [docker-bench-security:latest]
```
from showing up in tests.

Signed-off-by: will Farrell <iam@willfarrell.ca>