### PR TITLE
Add wrapper to download specific version on the fly.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,7 @@
 FROM alpine:3.5
 
+ENV DBS_VERSION=
+
 LABEL org.label-schema.name="docker-bench-security" \
       org.label-schema.url="https://dockerbench.com" \
       org.label-schema.vcs-url="https://github.com/docker/docker-bench-security.git"
@@ -8,9 +10,11 @@ RUN \
   apk upgrade --no-cache && \
   apk add --no-cache \
     docker \
-    dumb-init && \
+    dumb-init \
+    openssl && \
   rm -rf /usr/bin/docker-* /usr/bin/dockerd && \
-  mkdir /usr/local/bin/tests
+  mkdir /usr/local/bin/tests && \
+  mkdir /usr/share/docker-bench-security
 
 COPY ./*.sh /usr/local/bin/
 
@@ -20,5 +24,4 @@ WORKDIR /usr/local/bin
 
 HEALTHCHECK CMD exit 0
 
-ENTRYPOINT [ "/usr/bin/dumb-init", "docker-bench-security.sh" ]
-
+ENTRYPOINT [ "/usr/bin/dumb-init", "get-specific-version.sh", "docker-bench-security.sh" ]

--- a/get-specific-version.sh
+++ b/get-specific-version.sh
@@ -1,18 +1,20 @@
 #!/bin/sh
 if [ -n "${DBS_VERSION}" ]; then
-  if [ ! -f /usr/share/docker-bench-security/v${DBS_VERSION}.tar.gz ]; then
-    echo "Getting docker-bench-security v${DBS_VERSION}..."
-    wget -q -P /usr/share/docker-bench-security/ https://github.com/docker/docker-bench-security/archive/v${DBS_VERSION}.tar.gz
-    rm -rf /usr/share/docker-bench-security/docker-bench-security-${DBS_VERSION}/
-    tar xfz /usr/share/docker-bench-security/v${DBS_VERSION}.tar.gz -C /usr/share/docker-bench-security/
+  if [ ! -f /usr/share/docker-bench-security/${DBS_VERSION}.tar.gz ]; then
+    echo "Getting docker-bench-security ${DBS_VERSION}..."
+    wget -q -P /usr/share/docker-bench-security/ https://github.com/docker/docker-bench-security/archive/${DBS_VERSION}.tar.gz
+    rm -rf /usr/share/docker-bench-security/${DBS_VERSION}/
+    mkdir -p /usr/share/docker-bench-security/${DBS_VERSION}/
+    tar xfz /usr/share/docker-bench-security/${DBS_VERSION}.tar.gz -C /usr/share/docker-bench-security/${DBS_VERSION} --strip 1 --overwrite
+    rm -rfv /usr/share/docker-bench-security/${DBS_VERSION}.tar.gz
   fi
-  
-  if [ -d /usr/share/docker-bench-security/docker-bench-security-${DBS_VERSION}/ ]; then
+
+  if [ $(find /usr/share/docker-bench-security/ | wc -l) -gt 1  ]; then
     rm -rf /usr/local/bin/docker-bench-security.sh /usr/local/bin/helper_lib.sh /usr/local/bin/output_lib.sh
     rm -rf /usr/local/bin/tests/*
-  
-    cp -r /usr/share/docker-bench-security/docker-bench-security-${DBS_VERSION}/*.sh /usr/local/bin/
-    cp -r /usr/share/docker-bench-security/docker-bench-security-${DBS_VERSION}/tests/*.sh /usr/local/bin/tests/
+
+    cp -r /usr/share/docker-bench-security/${DBS_VERSION}/*.sh /usr/local/bin/
+    cp -r /usr/share/docker-bench-security/${DBS_VERSION}/tests/*.sh /usr/local/bin/tests/
   fi
 fi
 

--- a/get-specific-version.sh
+++ b/get-specific-version.sh
@@ -5,16 +5,16 @@ if [ -n "${DBS_VERSION}" ]; then
     wget -q -P /usr/share/docker-bench-security/ https://github.com/docker/docker-bench-security/archive/${DBS_VERSION}.tar.gz
     rm -rf /usr/share/docker-bench-security/${DBS_VERSION}/
     mkdir -p /usr/share/docker-bench-security/${DBS_VERSION}/
-    tar xfz /usr/share/docker-bench-security/${DBS_VERSION}.tar.gz -C /usr/share/docker-bench-security/${DBS_VERSION} --strip 1 --overwrite
+    tar xfzv /usr/share/docker-bench-security/${DBS_VERSION}.tar.gz -C /usr/share/docker-bench-security/${DBS_VERSION} --strip 1 --overwrite
     rm -rfv /usr/share/docker-bench-security/${DBS_VERSION}.tar.gz
   fi
 
-  if [ $(find /usr/share/docker-bench-security/ | wc -l) -gt 1  ]; then
-    rm -rf /usr/local/bin/docker-bench-security.sh /usr/local/bin/helper_lib.sh /usr/local/bin/output_lib.sh
-    rm -rf /usr/local/bin/tests/*
+  if [ $(find /usr/share/docker-bench-security/${DBS_VERSION}/ | wc -l) -gt 1  ]; then
+    rm -rfv /usr/local/bin/docker-bench-security.sh /usr/local/bin/helper_lib.sh /usr/local/bin/output_lib.sh
+    rm -rfv /usr/local/bin/tests/*
 
-    cp -r /usr/share/docker-bench-security/${DBS_VERSION}/*.sh /usr/local/bin/
-    cp -r /usr/share/docker-bench-security/${DBS_VERSION}/tests/*.sh /usr/local/bin/tests/
+    cp -rv /usr/share/docker-bench-security/${DBS_VERSION}/*.sh /usr/local/bin/
+    cp -rv /usr/share/docker-bench-security/${DBS_VERSION}/tests/*.sh /usr/local/bin/tests/
   fi
 fi
 

--- a/get-specific-version.sh
+++ b/get-specific-version.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+if [ -n "${DBS_VERSION}" ]; then
+  if [ ! -f /usr/share/docker-bench-security/v${DBS_VERSION}.tar.gz ]; then
+    echo "Getting docker-bench-security v${DBS_VERSION}..."
+    wget -q -P /usr/share/docker-bench-security/ https://github.com/docker/docker-bench-security/archive/v${DBS_VERSION}.tar.gz
+    rm -rf /usr/share/docker-bench-security/docker-bench-security-${DBS_VERSION}/
+    tar xfz /usr/share/docker-bench-security/v${DBS_VERSION}.tar.gz -C /usr/share/docker-bench-security/
+  fi
+  
+  if [ -d /usr/share/docker-bench-security/docker-bench-security-${DBS_VERSION}/ ]; then
+    rm -rf /usr/local/bin/docker-bench-security.sh /usr/local/bin/helper_lib.sh /usr/local/bin/output_lib.sh
+    rm -rf /usr/local/bin/tests/*
+  
+    cp -r /usr/share/docker-bench-security/docker-bench-security-${DBS_VERSION}/*.sh /usr/local/bin/
+    cp -r /usr/share/docker-bench-security/docker-bench-security-${DBS_VERSION}/tests/*.sh /usr/local/bin/tests/
+  fi
+fi
+
+exec "$@"


### PR DESCRIPTION
Can potentially close #223 

If the environment variable DBS_VERSION is passed to docker run, the container will try to download that specific version from the release page. If the variable is not passed, then docker-bench-security will operate as usual.

Signed-off-by: Julien Del-Piccolo <julien@del-piccolo.com>