### PR TITLE
update 2.14

### DIFF
--- a/tests/2_docker_daemon_configuration.sh
+++ b/tests/2_docker_daemon_configuration.sh
@@ -178,6 +178,8 @@ if docker info 2>/dev/null | grep -e "Live Restore Enabled:\s*true\s*" >/dev/nul
 else
   if docker info 2>/dev/null | grep -e "Swarm:*\sactive\s*" >/dev/null 2>&1; then
     pass "$check_2_14 (Incompatible with swarm mode)"
+  elif get_docker_effective_command_line_args '--live-restore' | grep "live-restore" >/dev/null 2>&1; then
+    pass "$check_2_14"
   else
     warn "$check_2_14"
   fi


### PR DESCRIPTION
Regarding the rule **:

CIS benchmark document says:

Audit:
`ps -ef | grep dockerd`
Ensure that the '--live-restore' parameter is set.

This PR update the rule to check on command line arg, and not only on `docker info result`