### PR TITLE
use mountpoint to check if /var/lib/docker is on separate partition

### DIFF
--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -8,6 +8,8 @@ auditrules="/etc/audit/audit.rules"
 check_1_1="1.1  - Ensure a separate partition for containers has been created"
 if grep /var/lib/docker /etc/fstab >/dev/null 2>&1; then
   pass "$check_1_1"
+elif mountpoint -q  -- /var/lib/docker >/dev/null 2>&1; then
+  pass "$check_1_1"
 else
   warn "$check_1_1"
 fi


### PR DESCRIPTION
Signed-off-by: Julien Garcia Gonzalez <julien@giantswarm.io>

Regarding the rule *1.1  - Ensure a separate partition for containers has been created*, use `mountpoint -q -- /var/lib/docker` to validate `/var/lib/docker` is mounted. 

For eg, on Container Linux, there no fstab, and partition are mounted via systemd