### PR TITLE
Add "--userns host" to `docker run` example

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ The easiest way to run your hosts against the Docker Bench for Security is by
 running our pre-built container:
 
 ```sh
-docker run -it --net host --pid host --cap-add audit_control \
+docker run -it --net host --pid host --userns host --cap-add audit_control \
     -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
     -v /var/lib:/var/lib \
     -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
If UID remapping is configured as a default, it has to be defeated for running the benchmark.