### PR TITLE
Trivial: fixed typo in README file.

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,5 +79,5 @@ cd docker-bench-security
 sudo sh docker-bench-security.sh
 ```
 
-This script was build to be POSIX 2004 compliant, so it should be portable
+This script was built to be POSIX 2004 compliant, so it should be portable
 across any Unix platform.


### PR DESCRIPTION
Fixed a small typo; changed “[…] was build to” to “[…] was built to”

Signed-off-by: Ernst de Haan <ernst@ernstdehaan.com>