### PR TITLE
Replace netstat by ss

### DIFF
--- a/distros/Dockerfile.centos
+++ b/distros/Dockerfile.centos
@@ -4,7 +4,7 @@ FROM centos
 
 MAINTAINER smccarty@redhat.com
 
-RUN yum install -y docker net-tools audit procps-ng; yum clean all
+RUN yum install -y docker iproute audit procps-ng; yum clean all
 
 RUN mkdir /docker-bench-security
 

--- a/distros/Dockerfile.debian
+++ b/distros/Dockerfile.debian
@@ -8,7 +8,7 @@ RUN \
     apt-get update && \
     apt-get -y upgrade && \
     apt-get -y install auditd ca-certificates docker.io \
-      gawk net-tools procps --no-install-recommends && \
+      gawk iproute2 procps --no-install-recommends && \
     apt-get -y clean && \
     apt-get -y autoremove && \
     rm -rf /var/lib/apt/lists/* \

--- a/distros/Dockerfile.openSUSE
+++ b/distros/Dockerfile.openSUSE
@@ -4,7 +4,7 @@ FROM opensuse
 
 MAINTAINER security@suse.com
 
-RUN zypper -n in docker net-tools audit
+RUN zypper -n in docker iproute2 audit
 
 RUN mkdir /docker-bench-security
 

--- a/distros/Dockerfile.rhel
+++ b/distros/Dockerfile.rhel
@@ -7,7 +7,7 @@ MAINTAINER smccarty@redhat.com
 RUN yum install -y yum-utils; yum clean all
 RUN yum-config-manager --disable "*" &>/dev/null
 RUN yum-config-manager --enable rhel-7-server-rpms --enable rhel-7-server-extras-rpms
-RUN yum install -y docker net-tools audit procps-ng; yum clean all
+RUN yum install -y docker iproute audit procps-ng; yum clean all
 
 RUN mkdir /docker-bench-security
 

--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -19,7 +19,7 @@ myname=$(basename "${this_path}")     ## file name of this script.
 export PATH=/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin/
 
 # Check for required program(s)
-req_progs='awk docker grep netstat stat'
+req_progs='awk docker grep ss stat'
 for p in $req_progs; do
   command -v "$p" >/dev/null 2>&1 || { printf "%s command not found.\n" "$p"; exit 1; }
 done

--- a/tests/7_docker_swarm_configuration.sh
+++ b/tests/7_docker_swarm_configuration.sh
@@ -32,7 +32,7 @@ fi
 # 7.3
 check_7_3="7.3  - Ensure swarm services are binded to a specific host interface"
 if docker info 2>/dev/null | grep -e "Swarm:*\sactive\s*" >/dev/null 2>&1; then
-  netstat -lnt | grep -e '\[::]:2377 ' -e ':::2377' -e '*:2377 ' -e ' 0\.0\.0\.0:2377 ' >/dev/null 2>&1
+  ss -lnt | grep -e '\[::]:2377 ' -e ':::2377' -e '*:2377 ' -e ' 0\.0\.0\.0:2377 ' >/dev/null 2>&1
   if [ $? -eq 1 ]; then
     pass "$check_7_3"
     logjson "7.3" "PASS"


### PR DESCRIPTION
ss(8) is a modern replacement for netstat(8). The former is slowly replacing
the latter in major Linux distributions, which makes it necessary to switch
at some point.

This addresses #278.