### PR TITLE
add -e option to exclude checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,8 @@ version 1.13.0 or later.
   -h           optional  Print this help message
   -l FILE      optional  Log output in FILE
   -c CHECK     optional  Comma delimited list of specific check(s)
-  -x EXCLUDE   optional  Comma delimited list of patterns within a container to exclude from check
+  -e CHECK     optional  Comma delimited list of specific check(s) to exclude
+  -x EXCLUDE   optional  Comma delimited list of patterns within a container name to exclude from check
 ```
 
 By default the Docker Bench for Security script will run all available CIS tests


### PR DESCRIPTION
Add `-e` option to exclude checks from the CIS group of functions #298 

```
$ sudo sh docker-bench-security.sh -e check_1_1,check_1_2,check_1_3
# ------------------------------------------------------------------------------
# Docker Bench for Security v1.3.4
#
# Docker, Inc. (c) 2015-
#
# Checks for dozens of common best-practices around deploying Docker containers in production.
# Inspired by the CIS Docker Community Edition Benchmark v1.1.0.
# ------------------------------------------------------------------------------

Initializing tor maj 10 12:49:22 UTC 2018

[INFO] 1.4  - Ensure only trusted users are allowed to control Docker daemon
[INFO]      * docker:x:993:vagrant
[WARN] 1.5  - Ensure auditing is configured for the Docker daemon
[WARN] 1.6  - Ensure auditing is configured for Docker files and directories - /var/lib/docker
[WARN] 1.7  - Ensure auditing is configured for Docker files and directories - /etc/docker
```

Signed-off-by: Thomas Sjögren <konstruktoid@users.noreply.github.com>