### PR TITLE
fix count total_containers for swarm mode

### DIFF
--- a/tests/6_docker_security_operations.sh
+++ b/tests/6_docker_security_operations.sh
@@ -32,7 +32,7 @@ check_6_1() {
 check_6_2() {
   check_6_2="6.2  - Avoid container sprawl"
   totalChecks=$((totalChecks + 1))
-  total_containers=$(docker info 2>/dev/null | grep "Containers" | awk '{print $2}')
+  total_containers=$(docker info 2>/dev/null | grep "^Containers" | awk '{print $2}')
   running_containers=$(docker ps -q | wc -l | awk '{print $1}')
   diff="$((total_containers - running_containers))"
   if [ "$diff" -gt 25 ]; then


### PR DESCRIPTION
[INFO]      * There are currently: 51 images
./tests/6_docker_security_operations.sh: line 37: 88
Containers:
Containers:
Containers:: syntax error in expression (error token is "Containers:
Containers:
Containers:")

this is because the script search for Containers, but docker info print a tree:
$ docker info | grep "Containers"
Containers: 88
  └ Containers: 46 (29 Running, 0 Paused, 17 Stopped)
  └ Containers: 22 (16 Running, 0 Paused, 6 Stopped)
  └ Containers: 20 (11 Running, 0 Paused, 9 Stopped)

wiith this fix the script is able to capture only the first line that has the total numbers of containers


Signed-off-by: Daniele Marcocci <daniele.marcocci@par-tec.it>