### PR TITLE
fix for path variable

### DIFF
--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -22,7 +22,7 @@ readonly version
 readonly this_path
 readonly myname
 
-export PATH=/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin/
+export PATH=$PATH:/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin/
 
 # Check for required program(s)
 req_progs='awk docker grep ss stat'


### PR DESCRIPTION
docker-bench-security.sh overwrites the PATH variable which makes problems if eg the docker binary is at a different installation directory. This fix includes the originl PATH variable content.