### PR TITLE
Update Alpine Linux to Version 3.8 (latest)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.7
+FROM alpine:3.8
 
 LABEL \
   org.label-schema.name="docker-bench-security" \


### PR DESCRIPTION
# Update Alpine Linux to Version 3.8 (latest)

Hi @konstruktoid,

just another small PR to update Alpine Linux to the latest Version.

Docker Hub: https://hub.docker.com/_/alpine/

Cheers Maik



![alpine-update](https://media.giphy.com/media/qhhamrBnxSKNG/giphy.gif)
Signed-off-by: Maik Ellerbrock <opensource@frapsoft.com>