### PR TITLE
Updated README.md / Added -t option

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ version 1.13.0 or later.
   -e CHECK     optional  Comma delimited list of specific check(s) to exclude
   -i INCLUDE   optional  Comma delimited list of patterns within a container name to check
   -x EXCLUDE   optional  Comma delimited list of patterns within a container name to exclude from check
+  -t TARGET    optional  Comma delimited list of images name to check
 ```
 
 By default the Docker Bench for Security script will run all available CIS tests

--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -46,7 +46,7 @@ usage () {
   -e CHECK     optional  Comma delimited list of specific check(s) to exclude
   -i INCLUDE   optional  Comma delimited list of patterns within a container name to check
   -x EXCLUDE   optional  Comma delimited list of patterns within a container name to exclude from check
-  -t TARGET    optional  Comma delimited list of images name to check.
+  -t TARGET    optional  Comma delimited list of images name to check
 EOF
 }
 


### PR DESCRIPTION
Hi, Thank you for awesome tools 👍 

# What

I found that `-t` option of `docker-bench-security.sh` is missed in `README.md`.
So, I updated `README.md`.

And more, I improved option description style (unnecessary `.`) 🐳 

# Check

```sh
$ ./docker-bench-security.sh -h
  usage: docker-bench-security.sh [options]

  -b           optional  Do not print colors
  -h           optional  Print this help message
  -l FILE      optional  Log output in FILE
  -c CHECK     optional  Comma delimited list of specific check(s)
  -e CHECK     optional  Comma delimited list of specific check(s) to exclude
  -i INCLUDE   optional  Comma delimited list of patterns within a container name to check
  -x EXCLUDE   optional  Comma delimited list of patterns within a container name to exclude from check
  -t TARGET    optional  Comma delimited list of images name to check
```

Thanks 👍 