### PR TITLE
Test 1_1 fails when user namespaces are enabled

### DIFF
--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -18,14 +18,26 @@ check_1_1() {
 
   totalChecks=$((totalChecks + 1))
 
-  if mountpoint -q -- "$(docker info -f '{{ .DockerRootDir }}')" >/dev/null 2>&1; then
-    pass "$check_1_1"
-    resulttestjson "PASS"
-    currentScore=$((currentScore + 1))
+  if [[ "$(docker info -f '{{ .SecurityOptions }}')" =~ .*userns.* ]]; then
+    if mountpoint -q -- "$(dirname "$(docker info -f '{{ .DockerRootDir }}')")" >/dev/null 2>&1; then
+      pass "$check_1_1"
+      resulttestjson "PASS"
+      currentScore=$((currentScore + 1))
+    else
+      warn "$check_1_1"
+      resulttestjson "WARN"
+      currentScore=$((currentScore - 1))
+    fi
   else
-    warn "$check_1_1"
-    resulttestjson "WARN"
-    currentScore=$((currentScore - 1))
+    if mountpoint -q -- "$(docker info -f '{{ .DockerRootDir }}')" >/dev/null 2>&1; then
+      pass "$check_1_1"
+      resulttestjson "PASS"
+      currentScore=$((currentScore + 1))
+    else
+      warn "$check_1_1"
+      resulttestjson "WARN"
+      currentScore=$((currentScore - 1))
+    fi
   fi
 }
 


### PR DESCRIPTION
When user namespaces are enabled as per test 2_8, this causes test 1_1 to fail because the Docker Root Dir is set to for example: /var/lib/docker/808080:808080.

This adds a test to see if userns is enabled and uses the dirname utility to get the parent directory, which should be the mount point.