### PR TITLE
Update to Alpine 3.9 (CVE-2019-5021)

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.8
+FROM alpine:3.9
 
 LABEL \
   org.label-schema.name="docker-bench-security" \


### PR DESCRIPTION
Hi @konstruktoid,

let's update to Alpine 3.9 to patch [CVE-2019-5021](https://nvd.nist.gov/vuln/detail/CVE-2019-5021).
More Informations can be found [here](https://www.alpinelinux.org/posts/Docker-image-vulnerability-CVE-2019-5021.html).
![alarm](https://media.giphy.com/media/YO7P8VC7nlQlO/giphy.gif)

Cheers,
Maik
