### PR TITLE
Fixed exclude flag issue with functions_lib.sh

### DIFF
--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -138,7 +138,7 @@ main () {
     cis
   elif [ -z "$check" ] && [ "$checkexclude" ]; then
     checkexcluded="$(echo ",$checkexclude" | sed -e 's/^/\^/g' -e 's/,/\$|/g' -e 's/$/\$/g')"
-    for c in $(grep 'check_[0-9]' functions_lib.sh | grep -vE "$checkexcluded"); do
+    for c in $(grep -E 'check_[0-9]|check_[a-z]' functions_lib.sh | grep -vE "$checkexcluded"); do
       "$c"
     done
   else


### PR DESCRIPTION
Hi,

There is a bug when using the -e flag, this is because of the way the functions_lib.sh is called within docker-bench-security.sh when it is set. This is because of line 141 "grep 'check_[0-9]'". It is not checking for functions that are all text, two that are used are: check_product_license and check_running_containers. This means if the -e flag is set these functions are not ran. This causes the "out of range" errors because the variables set within these functions "enterprise_license" and "running_containers" respectively are not set when checked. 

However, "running_containers" is set within the main docker-bench-security.sh so no "out of range" errors are shown because it is never blank (check_running_containers is still useful though because it informs the user that no containers are running).

I have fixed both issues with the following PR. As you can it simply includes these missing check functions when the -e flag is set. 