### PR TITLE
fix: allow combining include and exclude

### DIFF
--- a/README.md
+++ b/README.md
@@ -71,6 +71,9 @@ will only run check `2.2 Ensure the logging level is set to 'info'`.
 `sh docker-bench-security.sh -l /tmp/docker-bench-security.sh.log -e check_2_2`
 will run all available checks except `2.2 Ensure the logging level is set to 'info'`.
 
+`sh docker-bench-security.sh -l /tmp/docker-bench-security.sh.log -c container_images -e check_4_5`
+will run just the container_images checks except `4.5 Ensure Content trust for Docker is Enabled`
+
 Note that when submitting checks, provide information why it is a
 reasonable test to add and please include some kind of official documentation
 verifying that information.

--- a/README.md
+++ b/README.md
@@ -71,6 +71,13 @@ will only run check `2.2 Ensure the logging level is set to 'info'`.
 `sh docker-bench-security.sh -l /tmp/docker-bench-security.sh.log -e check_2_2`
 will run all available checks except `2.2 Ensure the logging level is set to 'info'`.
 
+`sh docker-bench-security.sh -l /tmp/docker-bench-security.sh.log -e docker_enterprise_configuration`
+will run all available checks except the docker_enterprise_configuration group
+
+`sh docker-bench-security.sh -l /tmp/docker-bench-security.sh.log -e docker_enterprise_configuration,check_2_2`
+will run all available checks except the docker_enterprise_configuration group
+and `2.2 Ensure the logging level is set to 'info'`
+
 `sh docker-bench-security.sh -l /tmp/docker-bench-security.sh.log -c container_images -e check_4_5`
 will run just the container_images checks except `4.5 Ensure Content trust for Docker is Enabled`
 

--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -144,7 +144,15 @@ main () {
   else
     for i in $(echo "$check" | sed "s/,/ /g"); do
       if command -v "$i" 2>/dev/null 1>&2; then
-        "$i"
+        if [ "$checkexclude" ]; then
+          checkexcluded="$(echo ",$checkexclude" | sed -e 's/^/\^/g' -e 's/,/\$|/g' -e 's/$/\$/g')"
+          included_checks=$(sed -ne "/$i() {/,/}/{/check/p}" functions_lib.sh | grep -vE "$checkexcluded")
+          for check in $included_checks; do
+            "$check"
+          done
+        else
+          "$i"
+        fi
       else
         echo "Check \"$i\" doesn't seem to exist."
         continue

--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -21,7 +21,7 @@ readonly version
 readonly this_path
 readonly myname
 
-# export PATH="$PATH:/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin/"
+export PATH="$PATH:/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin/"
 
 # Check for required program(s)
 req_progs='awk docker grep ss stat'

--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -21,7 +21,7 @@ readonly version
 readonly this_path
 readonly myname
 
-export PATH="$PATH:/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin/"
+# export PATH="$PATH:/bin:/sbin:/usr/bin:/usr/local/bin:/usr/sbin/"
 
 # Check for required program(s)
 req_progs='awk docker grep ss stat'
@@ -102,7 +102,7 @@ main () {
     fi
   done
 
-  # get the image id of the docker_bench_security_image, memorize it:
+  # Get the image id of the docker_bench_security_image, memorize it:
   benchimagecont="nil"
   for c in $(docker images | sed '1d' | awk '{print $3}'); do
     if docker inspect --format '{{ .Config.Labels }}' "$c" | \
@@ -135,29 +135,44 @@ main () {
   done
 
   if [ -z "$check" ] && [ ! "$checkexclude" ]; then
+    # No options just run
     cis
-  elif [ -z "$check" ] && [ "$checkexclude" ]; then
-    checkexcluded="$(echo ",$checkexclude" | sed -e 's/^/\^/g' -e 's/,/\$|/g' -e 's/$/\$/g')"
-    for c in $(grep -E 'check_[0-9]|check_[a-z]' functions_lib.sh | grep -vE "$checkexcluded"); do
-      "$c"
-    done
-  else
-    for i in $(echo "$check" | sed "s/,/ /g"); do
-      if command -v "$i" 2>/dev/null 1>&2; then
-        if [ "$checkexclude" ]; then
-          checkexcluded="$(echo ",$checkexclude" | sed -e 's/^/\^/g' -e 's/,/\$|/g' -e 's/$/\$/g')"
-          for check in $(sed -ne "/$i() {/,/}/{/{/d; /}/d; p}" functions_lib.sh | grep -vE "$checkexcluded"); do
-            "$check"
-          done
-        else
-          "$i"
-        fi
-      else
-        echo "Check \"$i\" doesn't seem to exist."
-        continue
-      fi
-    done
+  elif [ -z "$check" ]; then
+    # No check defined but excludes defined set to calls in cis() function
+    check=$(sed -ne "/cis() {/,/}/{/{/d; /}/d; p}" functions_lib.sh)
   fi
+
+  for c in $(echo "$check" | sed "s/,/ /g"); do
+    if ! command -v "$c" 2>/dev/null 1>&2; then
+      echo "Check \"$c\" doesn't seem to exist."
+      continue
+    fi
+    if [ -z "$checkexclude" ]; then
+      # No excludes just run the checks specified
+      "$c"
+    else
+      # Exludes specified and check exists
+      checkexcluded="$(echo ",$checkexclude" | sed -e 's/^/\^/g' -e 's/,/\$|/g' -e 's/$/\$/g')"
+
+      if echo "$c" | grep -E "$checkexcluded" 2>/dev/null 1>&2; then
+        # Excluded
+        continue
+      elif echo "$c" | grep -vE 'check_[0-9]|check_[a-z]' 2>/dev/null 1>&2; then
+        # Function not a check, fill loop_checks with all check from function
+        loop_checks="$(sed -ne "/$c() {/,/}/{/{/d; /}/d; p}" functions_lib.sh)"
+      else
+        # Just one check
+        loop_checks="$c"
+      fi
+
+      for lc in $loop_checks; do
+        if echo "$lc" | grep -vE "$checkexcluded" 2>/dev/null 1>&2; then
+          # Not excluded
+          "$lc"
+        fi
+      done
+    fi
+  done
 
   printf "\n"
   info "Checks: $totalChecks"

--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -146,7 +146,7 @@ main () {
       if command -v "$i" 2>/dev/null 1>&2; then
         if [ "$checkexclude" ]; then
           checkexcluded="$(echo ",$checkexclude" | sed -e 's/^/\^/g' -e 's/,/\$|/g' -e 's/$/\$/g')"
-          included_checks=$(sed -ne "/$i() {/,/}/{/check/p}" functions_lib.sh | grep -vE "$checkexcluded")
+          included_checks=$(sed -ne "/$i() {/,/}/{/{/d; /}/d; p}" functions_lib.sh | grep -vE "$checkexcluded")
           for check in $included_checks; do
             "$check"
           done

--- a/docker-bench-security.sh
+++ b/docker-bench-security.sh
@@ -146,8 +146,7 @@ main () {
       if command -v "$i" 2>/dev/null 1>&2; then
         if [ "$checkexclude" ]; then
           checkexcluded="$(echo ",$checkexclude" | sed -e 's/^/\^/g' -e 's/,/\$|/g' -e 's/$/\$/g')"
-          included_checks=$(sed -ne "/$i() {/,/}/{/{/d; /}/d; p}" functions_lib.sh | grep -vE "$checkexcluded")
-          for check in $included_checks; do
+          for check in $(sed -ne "/$i() {/,/}/{/{/d; /}/d; p}" functions_lib.sh | grep -vE "$checkexcluded"); do
             "$check"
           done
         else


### PR DESCRIPTION
### Reason for change

For a CI pipeline I was trying to scan just container images but without the healtcheck and docker trust check:
`./docker-bench-security.sh -i test -c container_images -e check_4_5,check_4_6`

This wasn't yet implemented so I took a stab at it.


### Technical explaining
The magic is in the sed:
```
sed -ne "/$i()/,/}/{ /{/d; /}/d; p}" functions_lib.sh
```

`$i` is the checkname, for example container_images so it matches on `container_images() {` until `}`
This results in:

```console
# sed -ne "/container_images() {/,/}/p" functions_lib.sh
container_images() {
  check_4
  check_4_1
  check_4_2
  check_4_3
  check_4_4
  check_4_5
  check_4_6
  check_4_7
  check_4_8
  check_4_9
  check_4_10
  check_4_11
  check_4_end
}
```

But I am just interested in the checks so just print the checks:

```console
# sed -ne "/container_images() {/,/}/{/check/p}" functions_lib.sh
  check_4
  check_4_1
  check_4_2
  check_4_3
  check_4_4
  check_4_5
  check_4_6
  check_4_7
  check_4_8
  check_4_9
  check_4_10
  check_4_11
  check_4_end
```

And then I just did the same grep trick as checkexclude to exlude test.