### PR TITLE
[Ubuntu] Fix issue with docker.service and docker.socket files not found

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,15 +33,30 @@ docker run -it --net host --pid host --userns host --cap-add audit_control \
     docker/docker-bench-security
 ```
 
-Don't forget to adjust the shared volumes according to your operating system,
-for example `Docker Desktop` on macOS don't have `/usr/lib/systemd` or the above
-Docker binaries.
+Don't forget to adjust the shared volumes according to your operating system. Some examples are:
+1. `Docker Desktop` on macOS don't have `/usr/lib/systemd` or the above Docker binaries.
 
 ```sh
 docker run -it --net host --pid host --userns host --cap-add audit_control \
     -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
     -v /etc:/etc \
     -v usr/local/bin/
+    -v /var/lib:/var/lib:ro \
+    -v /var/run/docker.sock:/var/run/docker.sock:ro \
+    --label docker_bench_security \
+    docker/docker-bench-security
+```
+
+2. On Ubuntu the `docker.service` and `docker.secret` files are located in `/lib/systemd/system` folder by default.
+
+```sh
+docker run -it --net host --pid host --userns host --cap-add audit_control \
+    -e DOCKER_CONTENT_TRUST=$DOCKER_CONTENT_TRUST \
+    -v /etc:/etc:ro \
+    -v /lib/systemd/system:/lib/systemd/system:ro \
+    -v /usr/bin/docker-containerd:/usr/bin/docker-containerd:ro \
+    -v /usr/bin/docker-runc:/usr/bin/docker-runc:ro \
+    -v /usr/lib/systemd:/usr/lib/systemd:ro \
     -v /var/lib:/var/lib:ro \
     -v /var/run/docker.sock:/var/run/docker.sock:ro \
     --label docker_bench_security \

--- a/helper_lib.sh
+++ b/helper_lib.sh
@@ -103,11 +103,13 @@ get_docker_configuration_file_args() {
   grep "$OPTION" "$CONFIG_FILE" | sed 's/.*://g' | tr -d '" ',
 }
 
-get_systemd_service_file() {
+get_service_file() {
   SERVICE="$1"
 
   if [ -f "/etc/systemd/system/$SERVICE" ]; then
     echo "/etc/systemd/system/$SERVICE"
+  elif [ -f "/lib/systemd/system/$SERVICE" ]; then
+    echo "/lib/systemd/system/$SERVICE"
   elif systemctl show -p FragmentPath "$SERVICE" 2> /dev/null 1>&2; then
     systemctl show -p FragmentPath "$SERVICE" | sed 's/.*=//'
   else

--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -214,7 +214,7 @@ check_1_2_6() {
   starttestjson "$id_1_2_6" "$desc_1_2_6"
 
   totalChecks=$((totalChecks + 1))
-  file="$(get_systemd_service_file docker.service)"
+  file="$(get_service_file docker.service)"
   if [ -f "$file" ]; then
     if command -v auditctl >/dev/null 2>&1; then
       if auditctl -l | grep "$file" >/dev/null 2>&1; then
@@ -251,7 +251,7 @@ check_1_2_7() {
   starttestjson "$id_1_2_7" "$desc_1_2_7"
 
   totalChecks=$((totalChecks + 1))
-  file="$(get_systemd_service_file docker.socket)"
+  file="$(get_service_file docker.socket)"
   if [ -e "$file" ]; then
     if command -v auditctl >/dev/null 2>&1; then
       if auditctl -l | grep "$file" >/dev/null 2>&1; then

--- a/tests/3_docker_daemon_configuration_files.sh
+++ b/tests/3_docker_daemon_configuration_files.sh
@@ -17,7 +17,7 @@ check_3_1() {
   starttestjson "$id_3_1" "$desc_3_1"
 
   totalChecks=$((totalChecks + 1))
-  file="$(get_systemd_service_file docker.service)"
+  file="$(get_service_file docker.service)"
   if [ -f "$file" ]; then
     if [ "$(stat -c %u%g $file)" -eq 00 ]; then
       pass "$check_3_1"
@@ -45,7 +45,7 @@ check_3_2() {
   starttestjson "$id_3_2" "$desc_3_2"
 
   totalChecks=$((totalChecks + 1))
-  file="$(get_systemd_service_file docker.service)"
+  file="$(get_service_file docker.service)"
   if [ -f "$file" ]; then
     if [ "$(stat -c %a $file)" -eq 644 ] || [ "$(stat -c %a $file)" -eq 600 ]; then
       pass "$check_3_2"
@@ -73,7 +73,7 @@ check_3_3() {
   starttestjson "$id_3_3" "$desc_3_3"
 
   totalChecks=$((totalChecks + 1))
-  file="$(get_systemd_service_file docker.socket)"
+  file="$(get_service_file docker.socket)"
   if [ -f "$file" ]; then
     if [ "$(stat -c %u%g $file)" -eq 00 ]; then
       pass "$check_3_3"
@@ -101,7 +101,7 @@ check_3_4() {
   starttestjson "$id_3_4" "$desc_3_4"
 
   totalChecks=$((totalChecks + 1))
-  file="$(get_systemd_service_file docker.socket)"
+  file="$(get_service_file docker.socket)"
   if [ -f "$file" ]; then
     if [ "$(stat -c %a $file)" -eq 644 ] || [ "$(stat -c %a $file)" -eq 600 ]; then
       pass "$check_3_4"


### PR DESCRIPTION
**Problem:**
On hosts running Ubuntu the default location for `docker.service` and `docker.socket` files is `/lib/systemd/system`. Under the hood the test suite currently [tries](https://github.com/docker/docker-bench-security/blob/d9a70bc006b15c8939de8587026ae1b1fbae20e2/helper_lib.sh#L106) to check for these files existence in other default location (`/etc/systemd/system/`), fails to do that an attempts to make a call to `systemctl` to get the actual one. This call always fails because `systemctl` is missing in the [docker image](https://github.com/docker/docker-bench-security/blob/master/Dockerfile#L1) (since it's based on `alpine`).

**Suggested solution**:
1. Add the default Ubuntu location check for  `docker.service` and `docker.socket` files (before the `systemctl` call)
2. Rename the `get_systemd_service_file` file to `get_service_file` (since the old name seems to be not very relevant: systemd is actually used as a fallback with default location returned if it's in place). 
3. Update the exceptions section in Readme.md so that people using the docker image against Ubuntu hosts won't forget to add an extra `/etc/systemd/system/` mount

**Note**:
I've also considered removing the systemd call with something more appropriate. but failed to find proper option (since the script should work not only in Alpine-based image but on other platform-specific images as well). So I'm really open to suggestions on that matter (left as is for now).