### PR TITLE
Remove prefix of check ID in description

### DIFF
--- a/tests/2_docker_daemon_configuration.sh
+++ b/tests/2_docker_daemon_configuration.sh
@@ -298,7 +298,7 @@ check_2_11() {
 # 2.12
 check_2_12() {
   id_2_12="2.12"
-  desc_2_12="2.12 Ensure centralized and remote logging is configured (Scored)"
+  desc_2_12="Ensure centralized and remote logging is configured (Scored)"
   check_2_12="$id_2_12  - $desc_2_12"
   starttestjson "$id_2_12" "$desc_2_12"
 


### PR DESCRIPTION
Remove the prefix of the check ID in description.
All other descriptions do not contain the ID, this is the only one which is causing inconsistent output.

For example:

```
[PASS] 2.11  - Ensure that authorization for Docker client commands is enabled (Scored)
[PASS] 2.12  - 2.12 Ensure centralized and remote logging is configured (Scored) 
[PASS] 2.13  - Ensure live restore is enabled (Scored)
```

