### PR TITLE
Support user namespaces in partition check (1.2.1)

### DIFF
--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -73,8 +73,9 @@ check_1_2_1() {
   starttestjson "$id_1_2_1" "$desc_1_2_1"
 
   totalChecks=$((totalChecks + 1))
-
-  if mountpoint -q -- "$(docker info -f '{{ .DockerRootDir }}')" >/dev/null 2>&1; then
+  local system_partition=$(df / --output=source 2> /dev/null | sed -n 2p)
+  local docker_partition=$(df "$(docker info -f '{{ .DockerRootDir }}')" --output=source 2> /dev/null | sed -n 2p)
+  if [ "$system_partition" != "$docker_partition" ] && [ ! -z "$docker_partition" ] ; then
     pass "$check_1_2_1"
     resulttestjson "PASS"
     currentScore=$((currentScore + 1))

--- a/tests/1_host_configuration.sh
+++ b/tests/1_host_configuration.sh
@@ -73,9 +73,12 @@ check_1_2_1() {
   starttestjson "$id_1_2_1" "$desc_1_2_1"
 
   totalChecks=$((totalChecks + 1))
-  local system_partition=$(df / --output=source 2> /dev/null | sed -n 2p)
-  local docker_partition=$(df "$(docker info -f '{{ .DockerRootDir }}')" --output=source 2> /dev/null | sed -n 2p)
-  if [ "$system_partition" != "$docker_partition" ] && [ ! -z "$docker_partition" ] ; then
+  docker_root_dir=$(docker info -f '{{ .DockerRootDir }}')
+  if docker info | grep -q userns ; then
+    docker_root_dir=$(readlink -f "$docker_root_dir/..")
+  fi
+
+  if mountpoint -q -- "$docker_root_dir" >/dev/null 2>&1; then
     pass "$check_1_2_1"
     resulttestjson "PASS"
     currentScore=$((currentScore + 1))


### PR DESCRIPTION
The current partition check (1.2.1) does not adequately support user namespaces (see e.g. #332). When [user namespaces](https://github.com/docker/labs/blob/master/security/userns/README.md) are enabled, Docker creates a subfolder in the Docker root directory (defaults to `/var/lib/docker`). This subfolder is based on the `user ID` and `group ID` of the user **dockermap**. The current check with `mountpoint -- "$(docker info -f '{{ .DockerRootDir }}')"` fails in this case, as the *Docker Root Dir* returns both the root directory and the subfolder, e.g. `/var/lib/docker/165536.165536/` instead of `/var/lib/docker/`.

The suggested code change identifies the partition the *Docker Root Dir* belongs to, using `df` instead of `mountpoint`. If this partition differs from the system's partition (identified by `/`), the test passes.

