### PR TITLE
Fix check_2 to -le 644

### DIFF
--- a/tests/3_docker_daemon_configuration_files.sh
+++ b/tests/3_docker_daemon_configuration_files.sh
@@ -47,7 +47,7 @@ check_3_2() {
   totalChecks=$((totalChecks + 1))
   file="$(get_service_file docker.service)"
   if [ -f "$file" ]; then
-    if [ "$(stat -c %a $file)" -eq 644 ] || [ "$(stat -c %a $file)" -eq 600 ]; then
+    if [ "$(stat -c %a $file)" -le 644 ]; then
       pass "$check_3_2"
       resulttestjson "PASS"
       currentScore=$((currentScore + 1))

--- a/tests/3_docker_daemon_configuration_files.sh
+++ b/tests/3_docker_daemon_configuration_files.sh
@@ -103,7 +103,7 @@ check_3_4() {
   totalChecks=$((totalChecks + 1))
   file="$(get_service_file docker.socket)"
   if [ -f "$file" ]; then
-    if [ "$(stat -c %a $file)" -eq 644 ] || [ "$(stat -c %a $file)" -eq 600 ]; then
+    if [ "$(stat -c %a $file)" -le 644 ]; then
       pass "$check_3_4"
       resulttestjson "PASS"
       currentScore=$((currentScore + 1))
@@ -159,7 +159,7 @@ check_3_6() {
   totalChecks=$((totalChecks + 1))
   directory="/etc/docker"
   if [ -d "$directory" ]; then
-    if [ "$(stat -c %a $directory)" -eq 755 ] || [ "$(stat -c %a $directory)" -eq 700 ]; then
+    if [ "$(stat -c %a $directory)" -le 755 ]; then
       pass "$check_3_6"
       resulttestjson "PASS"
       currentScore=$((currentScore + 1))
@@ -225,7 +225,7 @@ check_3_8() {
     fail=0
     perms=$(find "$directory" -type f -name '*.crt')
     for p in $perms; do
-      if [ "$(stat -c %a $p)" -ne 444 ] && [ "$(stat -c %a $p)" -ne 400 ]; then
+      if [ "$(stat -c %a $p)" -gt 444 ]; then
         fail=1
       fi
     done
@@ -293,7 +293,7 @@ check_3_10() {
     tlscacert=$(get_docker_effective_command_line_args '--tlscacert' | sed -n 's/.*tlscacert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
   fi
   if [ -f "$tlscacert" ]; then
-    if [ "$(stat -c %a $tlscacert)" -eq 444 ] || [ "$(stat -c %a $tlscacert)" -eq 400 ]; then
+    if [ "$(stat -c %a $tlscacert)" -le 444 ]; then
       pass "$check_3_10"
       resulttestjson "PASS"
       currentScore=$((currentScore + 1))
@@ -357,7 +357,7 @@ check_3_12() {
     tlscert=$(get_docker_effective_command_line_args '--tlscert' | sed -n 's/.*tlscert=\([^s]\)/\1/p' | sed 's/--/ --/g' | cut -d " " -f 1)
   fi
   if [ -f "$tlscert" ]; then
-    if [ "$(stat -c %a $tlscert)" -eq 444 ] || [ "$(stat -c %a $tlscert)" -eq 400 ]; then
+    if [ "$(stat -c %a $tlscert)" -le 444 ]; then
       pass "$check_3_12"
       resulttestjson "PASS"
       currentScore=$((currentScore + 1))
@@ -477,7 +477,7 @@ check_3_16() {
   totalChecks=$((totalChecks + 1))
   file="/var/run/docker.sock"
   if [ -S "$file" ]; then
-    if [ "$(stat -c %a $file)" -eq 660 ] || [  "$(stat -c %a $file)" -eq 600 ]; then
+    if [ "$(stat -c %a $file)" -le 660 ]; then
       pass "$check_3_16"
       resulttestjson "PASS"
       currentScore=$((currentScore + 1))
@@ -533,7 +533,7 @@ check_3_18() {
   totalChecks=$((totalChecks + 1))
   file="/etc/docker/daemon.json"
   if [ -f "$file" ]; then
-    if [ "$(stat -c %a $file)" -eq 644 ] || [  "$(stat -c %a $file)" -eq 640 ] || [ "$(stat -c %a $file)" -eq 600 ]; then
+    if [ "$(stat -c %a $file)" -le 644 ]; then
       pass "$check_3_18"
       resulttestjson "PASS"
       currentScore=$((currentScore + 1))
@@ -617,7 +617,7 @@ check_3_21() {
   totalChecks=$((totalChecks + 1))
   file="/etc/sysconfig/docker"
   if [ -f "$file" ]; then
-    if [ "$(stat -c %a $file)" -eq 644 ] || [ "$(stat -c %a $file)" -eq 600 ]; then
+    if [ "$(stat -c %a $file)" -le 644 ]; then
       pass "$check_3_21"
       resulttestjson "PASS"
       currentScore=$((currentScore + 1))
@@ -645,7 +645,7 @@ check_3_22() {
   totalChecks=$((totalChecks + 1))
   file="/etc/default/docker"
   if [ -f "$file" ]; then
-    if [ "$(stat -c %a $file)" -eq 644 ] || [ "$(stat -c %a $file)" -eq 600 ]; then
+    if [ "$(stat -c %a $file)" -le 644 ]; then
       pass "$check_3_22"
       resulttestjson "PASS"
       currentScore=$((currentScore + 1))


### PR DESCRIPTION
Issue #459 raised that check_2 was only checking for 644 or 600 permissions, this now checks for anything less than or equal to 644.

Signed-off-by: Niall T 19202716+jammasterj89@users.noreply.github.com