### PR TITLE
fix: set docker-bench-security to sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,5 +15,5 @@ HEALTHCHECK CMD exit 0
 
 WORKDIR /usr/local/bin
 
-ENTRYPOINT [ "/usr/bin/dumb-init", "docker-bench-security.sh" ]
+ENTRYPOINT [ "/usr/bin/dumb-init", "/bin/sh", "docker-bench-security.sh" ]
 CMD [""]


### PR DESCRIPTION
- Closes #473 
- Set script to execute with sh rather than bash
- Dockerfile is based on Alpine 13.3 that has sh and not bash