### PR TITLE
fix style and false warning in check_5_3

### DIFF
--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -113,9 +113,10 @@ check_5_3() {
   fail=0
   caps_containers=""
   for c in $containers; do
-    container_caps=$(docker inspect --format 'CapAdd={{ .HostConfig.CapAdd}}' "$c")
+    container_caps=$(docker inspect --format 'CapAdd={{ .HostConfig.CapAdd }}' "$c")
     caps=$(echo "$container_caps" | tr "[:lower:]" "[:upper:]" | \
       sed 's/CAPADD/CapAdd/' | \
+      sed -r "s/CAP_AUDIT_WRITE|CAP_CHOWN|CAP_DAC_OVERRIDE|CAP_FOWNER|CAP_FSETID|CAP_KILL|CAP_MKNOD|CAP_NET_BIND_SERVICE|CAP_NET_RAW|CAP_SETFCAP|CAP_SETGID|CAP_SETPCAP|CAP_SETUID|CAP_SYS_CHROOT|\s//g" | \
       sed -r "s/AUDIT_WRITE|CHOWN|DAC_OVERRIDE|FOWNER|FSETID|KILL|MKNOD|NET_BIND_SERVICE|NET_RAW|SETFCAP|SETGID|SETPCAP|SETUID|SYS_CHROOT|\s//g")
 
     if [ "$caps" != 'CapAdd=' ] && [ "$caps" != 'CapAdd=[]' ] && [ "$caps" != 'CapAdd=<no value>' ] && [ "$caps" != 'CapAdd=<nil>' ]; then


### PR DESCRIPTION
Hi @konstruktoid , I'm testing a container created with the command:

```bash
docker run --rm -it --cap-add CAP_SYS_CHROOT --name ubuntu  ubuntu bash
```

, where `CAP_SYS_CHROOT` is a default capability for containers.

In this case, running check_5_3 should not give warnings ( also I noticed that the default capabilities are trimmed ), but in fact, it gives output like:

```
[WARN] 5.3 - Ensure that Linux kernel capabilities are restricted within containers (Automated)
[WARN      * Capabilities added: CapAdd=[CAP_] to ubuntu
```

( If then adding some other extra caps, the output will be like: `CapAdd=[CAP_CAP_SYS_ADMIN]` )

This is because users may give cap agrs in the long form of `CAP_*`.

This commit will deal with this scenario and fix the false warning ( already tested with input args `CAP_SYS_CHROOT/SYS_CHROOT, CAP_SYS_ADMIN` ).

Also, it fixed the code style ( `{{ .HostConfig.CapAdd}}` -> `{{ .HostConfig.CapAdd }}` )