### PR TITLE
Fix check_2_7 TLS  check with json config

### DIFF
--- a/tests/2_docker_daemon_configuration.sh
+++ b/tests/2_docker_daemon_configuration.sh
@@ -154,7 +154,7 @@ check_2_7() {
   local check="$id - $desc"
   starttestjson "$id" "$desc"
 
-  if [ $(grep -E "host.*tcp://" "$CONFIG_FILE") ] || \
+  if $(grep -qE "host.*tcp://" "$CONFIG_FILE") || \
     [ $(get_docker_cumulative_command_line_args '-H' | grep -vE '(unix|fd)://') > /dev/null 2>&1 ]; then
     if [ $(get_docker_configuration_file_args '"tlsverify":' | grep 'true') ] || \
         [ $(get_docker_cumulative_command_line_args '--tlsverify' | grep 'tlsverify') >/dev/null 2>&1 ]; then


### PR DESCRIPTION
2.7 check always failed when the config file was a json format this pull request should fix it