### PR TITLE
Issue 521 restart policy

### DIFF
--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -595,19 +595,21 @@ check_5_14() {
   fail=0
   maxretry_unset_containers=""
   for c in $containers; do
-    for s in $(docker service ls --format '{{.Name}}'); do
-      if docker inspect "$c" --format '{{.Name}}' | grep -q "$s"; then
+    container_name=$(docker inspect "$c" --format '{{.Name}}')
+q    for s in $(docker service ls --format '{{.Name}}'); do
+      if echo $container_name | grep -q "$s"; then
         task_id=$(docker inspect "$c" --format '{{.Name}}' | awk -F '.' '{print $NF}')
         # a container name could arbitrary include a service one: it belongs to a service (created by Docker 
         # as part of the service), if the container task ID matches one of the task IDs of the service.
         if docker service ps --no-trunc "$s" --format '{{.ID}}' | grep -q "$task_id"; then
-          spolicy=$(docker inspect --format MaximumRetryCount='{{ .Spec.TaskTemplate.RestartPolicy.MaxAttempts }}' "$s")
+          spolicy=$(docker inspect --format MaxAttempts='{{ .Spec.TaskTemplate.RestartPolicy.MaxAttempts }}' "$s")
+          break
         fi
       fi
     done
     cpolicy=$(docker inspect --format MaximumRetryCount='{{ .HostConfig.RestartPolicy.MaximumRetryCount }}' "$c")
 
-    if [ "$cpolicy" != "MaximumRetryCount=5" ] || [ "$spolicy" != "MaxAttempts=5" ]; then
+    if [ "$cpolicy" != "MaximumRetryCount=5" ] && [ "$spolicy" != "MaxAttempts=5" ]; then
       # If it's the first container, fail the test
       if [ $fail -eq 0 ]; then
         warn -s "$check"

--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -596,7 +596,7 @@ check_5_14() {
   maxretry_unset_containers=""
   for c in $containers; do
     container_name=$(docker inspect "$c" --format '{{.Name}}')
-q    for s in $(docker service ls --format '{{.Name}}'); do
+    for s in $(docker service ls --format '{{.Name}}'); do
       if echo $container_name | grep -q "$s"; then
         task_id=$(docker inspect "$c" --format '{{.Name}}' | awk -F '.' '{print $NF}')
         # a container name could arbitrary include a service one: it belongs to a service (created by Docker 

--- a/tests/5_container_runtime.sh
+++ b/tests/5_container_runtime.sh
@@ -595,9 +595,19 @@ check_5_14() {
   fail=0
   maxretry_unset_containers=""
   for c in $containers; do
-    policy=$(docker inspect --format MaximumRetryCount='{{ .HostConfig.RestartPolicy.MaximumRetryCount }}' "$c")
+    for s in $(docker service ls --format '{{.Name}}'); do
+      if docker inspect "$c" --format '{{.Name}}' | grep -q "$s"; then
+        task_id=$(docker inspect "$c" --format '{{.Name}}' | awk -F '.' '{print $NF}')
+        # a container name could arbitrary include a service one: it belongs to a service (created by Docker 
+        # as part of the service), if the container task ID matches one of the task IDs of the service.
+        if docker service ps --no-trunc "$s" --format '{{.ID}}' | grep -q "$task_id"; then
+          spolicy=$(docker inspect --format MaximumRetryCount='{{ .Spec.TaskTemplate.RestartPolicy.MaxAttempts }}' "$s")
+        fi
+      fi
+    done
+    cpolicy=$(docker inspect --format MaximumRetryCount='{{ .HostConfig.RestartPolicy.MaximumRetryCount }}' "$c")
 
-    if [ "$policy" != "MaximumRetryCount=5" ]; then
+    if [ "$cpolicy" != "MaximumRetryCount=5" ] || [ "$spolicy" != "MaxAttempts=5" ]; then
       # If it's the first container, fail the test
       if [ $fail -eq 0 ]; then
         warn -s "$check"


### PR DESCRIPTION
This fix double check for both the:
- container `MaximumRetryCount`
- service `MaxAttempts`

properties to be equal to 5.

Thus, fixing the #521 issue. The fix has been succesfully tested.