### PR TITLE
feat: use SHA instead of tags for base image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM alpine:3.18
+FROM alpine:3.18@sha256:eece025e432126ce23f223450a0326fbebde39cdf496a85d8c016293fc851978
 
 LABEL \
   org.label-schema.name="docker-bench-security" \


### PR DESCRIPTION
### Main Changes

- Added SHA commit reference instead of tags to anchor the base image

### Changelog

- 8bbdaf6 feat: use SHA instead of tags for base image by @UlisesGascon 

