### PR TITLE
modified get_docker_configuration_file_args jq command to remove null response

### DIFF
--- a/functions/helper_lib.sh
+++ b/functions/helper_lib.sh
@@ -123,7 +123,7 @@ get_docker_configuration_file_args() {
   get_docker_configuration_file
 
   if "$HAVE_JQ"; then
-    jq --monochrome-output --raw-output ".[\"${OPTION}\"]" "$CONFIG_FILE"
+    jq --monochrome-output --raw-output "if has(\"${OPTION}\") then .[\"${OPTION}\"] else \"\" end" "$CONFIG_FILE"
   else
     cat "$CONFIG_FILE" | tr , '\n' | grep "$OPTION" | sed 's/.*://g' | tr -d '" ',
   fi


### PR DESCRIPTION
By default, `jq` will return "null" (string) when no results are found, which means `get_docker_configuration_file_args` would return "null" instead of "" or true null. Checks like `check_2_3` that accept a blank/null response to pass would fail.

This modifies the `jq` command to look for `$OPTION` and if found, return the value of `$OPTION`, otherwise return no data.